### PR TITLE
Pointing to live twitter and tumblr resources.

### DIFF
--- a/IFComp/root/src/welcome.tt2
+++ b/IFComp/root/src/welcome.tt2
@@ -34,7 +34,7 @@
     <div class="col-sm-4">
         <h2>Stay comp-informed</h2>
     <p>
-        For news and updates, please <a href="http://blog.ifcomp.org">visit our blog</a> or <a href="twitter.com/ifcomp">follow us on Twitter</a>. We'll post updates throughout the runup to the June kickoff while this new website comes online, bit by bit.
+        For news and updates, please <a href="http://ifcomp.tumblr.com">visit our blog</a> or <a href="http://twitter.com/ifcomp">follow us on Twitter</a>. We'll post updates throughout the runup to the June kickoff while this new website comes online, bit by bit.
     </p>
     
       </div>


### PR DESCRIPTION
Just re-aiming the links on the front page to live twitter/tumblr resources. Was going to wait on the latter until we had blog.ifcomp.org, but I think this may be good enough for now?
