### PR TITLE
Adding support for a content warning field

### DIFF
--- a/IFComp/lib/IFComp/Form/Entry.pm
+++ b/IFComp/lib/IFComp/Form/Entry.pm
@@ -28,6 +28,10 @@ has_field 'blurb' => (
     type => 'TextArea',
 );
 
+has_field 'warning' => (
+    type => 'Text',
+);
+
 has_field 'author_pseudonym' => (
     type => 'Text',
     label => 'Displayed pseudonym or author-list (if different from your registered name)',

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -190,6 +190,11 @@ __PACKAGE__->table("entry");
   data_type: 'integer'
   is_nullable: 1
 
+=head2 warning
+
+  data_type: 'text'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -266,6 +271,8 @@ __PACKAGE__->add_columns(
   { data_type => "tinyint", is_nullable => 1 },
   "votes_cast",
   { data_type => "integer", is_nullable => 1 },
+  "warning",
+  { data_type => "text", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -372,8 +379,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-11-16 12:20:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iF3wtgC7dnsOjVdunwh+jA
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-12 21:16:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Q58ScE3jBt6Vxwf2yJJ1Cg
 
 use Moose::Util::TypeConstraints;
 use Lingua::EN::Numbers::Ordinate;

--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -11,6 +11,10 @@
         [% FILTER html_para %]
         	[% entry.blurb | html %]
         [% END %]
+        
+        [% IF entry.warning %]
+            <p><strong>Content warning:</strong> [% entry.warning %]</p>
+        [% END %]
 
         [% UNLESS entry.platform == 'other' %]
         <p><em><strong>Format:</strong> [% IF entry.platform == 'parchment' || entry.platform == 'inform-website' || entry.platform == 'inform' || entry.platform == 'quixe2' %]

--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -8,12 +8,15 @@
     
     <div class="col-xs-[% IF entry.cover_exists %]8[% ELSE %]12[% END %]">
         <p><strong>[% INCLUDE author_name.tt %]</strong></p>
+
         [% FILTER html_para %]
+
         	[% entry.blurb | html %]
-        [% END %]
-        
-        [% IF entry.warning %]
-            <p><strong>Content warning:</strong> [% entry.warning %]</p>
+
+            [% IF entry.warning %]
+                <p><strong>Content warning:</strong> [% entry.warning %]</p>
+            [% END %]
+
         [% END %]
 
         [% UNLESS entry.platform == 'other' %]

--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -10,14 +10,13 @@
         <p><strong>[% INCLUDE author_name.tt %]</strong></p>
 
         [% FILTER html_para %]
-
         	[% entry.blurb | html %]
-
-            [% IF entry.warning %]
-                <p><strong>Content warning:</strong> [% entry.warning %]</p>
-            [% END %]
-
         [% END %]
+
+        [% IF entry.warning %]
+            <p><strong>Content warning:</strong> [% entry.warning | html %]</p>
+        [% END %]
+
 
         [% UNLESS entry.platform == 'other' %]
         <p><em><strong>Format:</strong> [% IF entry.platform == 'parchment' || entry.platform == 'inform-website' || entry.platform == 'inform' || entry.platform == 'quixe2' %]

--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -53,6 +53,22 @@ Delete cover art file
 </div>
 
 <div class="panel panel-default">
+<div class="panel-heading"><h2>Content warnings</h2></div>
+<div class="panel-body">
+<p>
+You may optionally provide a brief warning that your work contains material some players may wish to know about before playing. Whether you provide a warning, and how you choose to word it, is entirely up to you. <a href="/about/faq#content-warnings" target="ifcomp-faq">See the FAQ for more information on IFComp's policies and suggestions regarding content warnings.</a>
+</p>
+
+<p>
+Your warning text, if present, will appear by your game's blurb on the IFComp ballot page, with the label "<strong>Content warning:</strong>". Players will have the option to hide content warnings from their ballots.
+</p>
+
+[% form.field('warning').render %]
+</div>
+</div>
+
+
+<div class="panel panel-default">
 <div class="panel-heading"><h2>Displayed name(s) and contact info</h2></div>
 <div class="panel-body">
 <p>If you wish, you can enter your game under a name (or a list of names) other than the name this website knows you by ([% c.user.name %]). Do this if you wish to enter your game under a pseudonym, or if your game has more than one author and you wish to equally credit all of them.</p>


### PR DESCRIPTION
This adds support for a content warning field to the database schema, the entry form, and the ballot. It is a free-text field, which authors can use however they wish (or not at all).

For the sake of flexibility, the IFComp committee decided to add this as a new field, rather than continue to recommend that authors include content warnings in their entries' blurb text. This implements that.

New text on the entry form fibs about judges' ability to hide content warnings. We'll return and add that feature prior to the stat of the 2017 judging period.

SQL:
`alter table entry add column warning text;`