### PR TITLE
Playtime field

### DIFF
--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -28,6 +28,7 @@ requires 'MooseX::ClassAttribute';
 requires 'Email::Sender::Simple';
 requires 'Email::MIME::Kit';
 requires 'Data::GUID';
+requires 'HTML::FormHandler' => '0.40067';
 requires 'HTML::FormHandler::Moose';
 requires 'HTML::FormHandler::Model::DBIC';
 requires 'DateTime::Format::SQLite';

--- a/IFComp/lib/IFComp/Form/Entry.pm
+++ b/IFComp/lib/IFComp/Form/Entry.pm
@@ -28,6 +28,20 @@ has_field 'blurb' => (
     type => 'TextArea',
 );
 
+has_field 'playtime' => (
+    type => 'Select',
+    label => 'Estimated play time',
+    empty_select => '',
+    options => [
+        { label => '15 minutes or less', value => 15, },
+        { label => '30 minutes',         value => 30, },
+        { label => '1 hour',             value => 60, },
+        { label => '1.5 hours',          value => 90, },
+        { label => '2 hours',            value => 120, },
+        { label => 'More than 2 hours',  value => 127, },
+    ],
+);
+
 has_field 'author_pseudonym' => (
     type => 'Text',
     label => 'Displayed pseudonym or author-list (if different from your registered name)',

--- a/IFComp/lib/IFComp/Form/Entry.pm
+++ b/IFComp/lib/IFComp/Form/Entry.pm
@@ -32,14 +32,15 @@ has_field 'playtime' => (
     type => 'Select',
     label => 'Estimated play time',
     empty_select => '',
-    options => [
-        { label => '15 minutes or less', value => 15, },
-        { label => '30 minutes',         value => 30, },
-        { label => '1 hour',             value => 60, },
-        { label => '1.5 hours',          value => 90, },
-        { label => '2 hours',            value => 120, },
-        { label => 'More than 2 hours',  value => 127, },
-    ],
+    options => [[
+        '15 minutes or less',
+        'half an hour',
+        'one hour',
+        'an hour and a half',
+        'two hours',
+        'longer than two hours',
+    ]],
+);
 
 has_field 'warning' => (
     type => 'Text',

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -195,6 +195,11 @@ __PACKAGE__->table("entry");
   data_type: 'text'
   is_nullable: 1
 
+=head2 playtime
+
+  data_type: 'tinyint'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -273,6 +278,8 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 1 },
   "warning",
   { data_type => "text", is_nullable => 1 },
+  "playtime",
+  { data_type => "tinyint", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -379,8 +386,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-12 21:16:14
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Q58ScE3jBt6Vxwf2yJJ1Cg
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-20 18:39:11
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eW2JHkzALPOPNVhd0rpQZw
 
 use Moose::Util::TypeConstraints;
 use Lingua::EN::Numbers::Ordinate;

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -197,7 +197,8 @@ __PACKAGE__->table("entry");
 
 =head2 playtime
 
-  data_type: 'tinyint'
+  data_type: 'enum'
+  extra: {list => ["15 minutes or less","half an hour","one hour","an hour and a half","two hours","longer than two hours"]}
   is_nullable: 1
 
 =cut
@@ -279,7 +280,20 @@ __PACKAGE__->add_columns(
   "warning",
   { data_type => "text", is_nullable => 1 },
   "playtime",
-  { data_type => "tinyint", is_nullable => 1 },
+  {
+    data_type => "enum",
+    extra => {
+      list => [
+        "15 minutes or less",
+        "half an hour",
+        "one hour",
+        "an hour and a half",
+        "two hours",
+        "longer than two hours",
+      ],
+    },
+    is_nullable => 1,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -386,8 +400,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-20 18:39:11
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eW2JHkzALPOPNVhd0rpQZw
+# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-24 15:39:26
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lmMJAPvE9llb6Qn6rBFUag
 
 use Moose::Util::TypeConstraints;
 use Lingua::EN::Numbers::Ordinate;

--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -12,6 +12,24 @@
         	[% entry.blurb | html %]
         [% END %]
 
+        [% IF entry.playtime %]
+        	<p><strong>Estimated playtime: </strong>
+        	[% IF entry.playtime == '15' %]
+        	    15 minutes or less
+        	[% ELSIF entry.playtime == '30' %]
+        	    30 minutes
+        	[% ELSIF entry.playtime == '60' %]
+        	    1 hour
+        	[% ELSIF entry.playtime == '90' %]
+        	    1.5 hours
+        	[% ELSIF entry.playtime == '120' %]
+        	    2 hours
+        	[% ELSE %]
+        	    More than 2 hours
+        	[% END %]
+        	</p>
+        [% END %]
+
         [% UNLESS entry.platform == 'other' %]
         <p><em><strong>Format:</strong> [% IF entry.platform == 'parchment' || entry.platform == 'inform-website' || entry.platform == 'inform' || entry.platform == 'quixe2' %]
             [% IF entry.is_zcode %]

--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -17,21 +17,7 @@
         [% END %]
 
         [% IF entry.playtime %]
-        	<p><strong>Estimated playtime: </strong>
-        	[% IF entry.playtime == '15' %]
-        	    15 minutes or less
-        	[% ELSIF entry.playtime == '30' %]
-        	    30 minutes
-        	[% ELSIF entry.playtime == '60' %]
-        	    1 hour
-        	[% ELSIF entry.playtime == '90' %]
-        	    1.5 hours
-        	[% ELSIF entry.playtime == '120' %]
-        	    2 hours
-        	[% ELSE %]
-        	    More than 2 hours
-        	[% END %]
-        	</p>
+        	<p><strong>Estimated playtime: </strong> [% entry.playtime %]</p>
         [% END %]
 
         [% UNLESS entry.platform == 'other' %]

--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -53,6 +53,20 @@ Delete cover art file
 </div>
 
 <div class="panel panel-default">
+<div class="panel-heading"><h2>Estimated play time</h2></div>
+<div class="panel-body">
+<p>
+Optionally, choose from the menu below a rough estimate of how much time you would expect a typical player to spend on this game.</p>
+
+<p>If you provide this estimate, it will be displayed by your game's listing on the IFComp ballot. This can help judges plan what entries to play and when, based on their own schedules.
+</p>
+
+[% form.field('playtime').render %]
+</div>
+</div>
+
+
+<div class="panel panel-default">
 <div class="panel-heading"><h2>Displayed name(s) and contact info</h2></div>
 <div class="panel-body">
 <p>If you wish, you can enter your game under a name (or a list of names) other than the name this website knows you by ([% c.user.name %]). Do this if you wish to enter your game under a pseudonym, or if your game has more than one author and you wish to equally credit all of them.</p>

--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -62,6 +62,11 @@ Optionally, choose from the menu below a rough estimate of how much time you wou
 </p>
 
 [% form.field('playtime').render %]
+
+</div>
+</div>
+
+<div class="panel panel-default">
 <div class="panel-heading"><h2>Content warnings</h2></div>
 <div class="panel-body">
 <p>


### PR DESCRIPTION
Adding support for a controlled-vocabulary estimated-playtime field to the entry form, and to entries' ballot display.

The form's options (15 minutes or less, 30 minutes, et cetera) are based on discussion of the IFComp committee, and are subject to tester feedback.