### PR TITLE
Triggering navbar collapse at a viewport width of 1000 pixels

### DIFF
--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -41,3 +41,48 @@ a.donate-link {
 a.donate-link:hover {
   color: white !important;
 }
+
+/* 
+Explicitly setting the navbar-collapse width.
+Bootstrap's default behavior is based on a narrower width, such that
+at some viewport widths the navbar content would flow to a second line,
+messing up the page layout.
+
+CSS based on: https://stackoverflow.com/questions/19703550/twitter-bootstrap-3-navbar-collapse-set-width-to-collapse#19705550
+*/ 
+@media (max-width: 1000px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-left,.navbar-right {
+        float: none !important;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-fixed-top {
+		top: 0;
+		border-width: 0 0 1px;
+	}
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+		margin-top: 7.5px;
+	}
+	.navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .collapse.in{
+  		display:block !important;
+	}
+}


### PR DESCRIPTION
This is overtly a big ol cut-n-paste from Stack Overflow, but it seems to be the generally accepted (if lengthy) CSS incantation to handle this precise issue. https://stackoverflow.com/questions/19703550/twitter-bootstrap-3-navbar-collapse-set-width-to-collapse#19705550

Using a value of 1000px as the trigger-width because 990px is the approximate width at which I'd see the issue illustrated by the screenshot on #46.