### PR TITLE
Fixes #81; Fixes #82. Constrain the title and subtitle to 128 charact…

### DIFF
--- a/IFComp/lib/IFComp/Form/Entry.pm
+++ b/IFComp/lib/IFComp/Form/Entry.pm
@@ -16,12 +16,14 @@ Readonly my $MAX_FILE_SIZE => 10485760;
 Readonly my $MAX_GAME_SIZE => 26214400;
 
 has_field 'title' => (
-    required => 1,
-    type => 'Text',
+    required  => 1,
+    type      => 'Text',
+    maxlength => 128,
 );
 
 has_field 'subtitle' => (
-    type => 'Text',
+    type      => 'Text',
+    maxlength => 128,
 );
 
 has_field 'blurb' => (


### PR DESCRIPTION
…ers each, and throw and display a form error if this is exceeded.