### PR TITLE
Add dbicdump script

### DIFF
--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -46,5 +46,6 @@ test_requires 'Test::WWW::Mechanize::Catalyst';
 
 on 'develop' => sub {
   requires 'Code::TidyAll';
+  requires 'DBIx::Class::Schema::Loader';
   requires 'Perl::Tidy';
 };

--- a/IFComp/lib/IFComp/Schema.pm
+++ b/IFComp/lib/IFComp/Schema.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema;
 
@@ -10,9 +11,10 @@ extends 'DBIx::Class::Schema';
 
 __PACKAGE__->load_namespaces;
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-01-15 17:49:13
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ky9maeBYyy5mD//QSeUGBQ
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uxXflUCGtsGN5LDbi7A+7A
 
 use MooseX::ClassAttribute;
 

--- a/IFComp/lib/IFComp/Schema/Result/AuthToken.pm
+++ b/IFComp/lib/IFComp/Schema/Result/AuthToken.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::AuthToken;
 
@@ -137,9 +138,10 @@ __PACKAGE__->belongs_to(
   },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-03-26 21:48:39
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:f8OfZrOIxQKK8OmUBVuk6Q
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Zu+hI5litqwYjsSutizhnw
 
 
 __PACKAGE__->meta->make_immutable;

--- a/IFComp/lib/IFComp/Schema/Result/Comp.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Comp.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Comp;
 
@@ -205,9 +206,10 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-12-27 04:55:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:IYAhuBMI6CH5OD4iCQrx+w
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:HLMI0dky1vwemnm0KYNCPA
 
 use DateTime::Moonpig;
 use Moose::Util::TypeConstraints;

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Entry;
 
@@ -399,9 +400,10 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-05-24 15:39:26
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lmMJAPvE9llb6Qn6rBFUag
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jIB96MSDHziEbORsmGEZ9A
 
 use Moose::Util::TypeConstraints;
 use Lingua::EN::Numbers::Ordinate;

--- a/IFComp/lib/IFComp/Schema/Result/EntryUpdate.pm
+++ b/IFComp/lib/IFComp/Schema/Result/EntryUpdate.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::EntryUpdate;
 
@@ -119,9 +120,10 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-02-23 16:14:35
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:FyfVsVjb9q5+0uEiKpAtLQ
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:us0rtUNb7uUsHJfu6KdcfA
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/EntryUpdate.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/FederatedSite.pm
+++ b/IFComp/lib/IFComp/Schema/Result/FederatedSite.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::FederatedSite;
 
@@ -117,9 +118,10 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-03-26 21:50:10
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:i7nM+TI1r6c1+aJ8pfKHqw
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:N2uQCAaiuIgIilmQOwORxA
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/FederatedSite.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/Prize.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Prize.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Prize;
 
@@ -204,9 +205,10 @@ __PACKAGE__->belongs_to(
   },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2015-05-13 10:29:38
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dtC2iwNeWXuX1u51KyT/Ng
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mVu/5JE+XtIgK6j11c1sYw
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/Prize.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/Role.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Role.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Role;
 
@@ -95,9 +96,10 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-02-23 16:14:35
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KY6p+XEFjCQe44teXH0kBg
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aG8V6anURGbNbtDnCLDwIg
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/Role.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/Session.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Session.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Session;
 
@@ -78,9 +79,10 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2015-07-09 21:52:30
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6lFaYQ3HpKL4SXYi7yGwQA
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8v1BC9lSa3qijqMuU3abHQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/IFComp/lib/IFComp/Schema/Result/Transcript.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Transcript.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Transcript;
 
@@ -163,9 +164,10 @@ __PACKAGE__->belongs_to(
   },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-08-26 18:15:45
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oPi1popV2LIROAMbz+PO6A
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qs+tL+YM6Le7woiZJRhKQw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/IFComp/lib/IFComp/Schema/Result/User.pm
+++ b/IFComp/lib/IFComp/Schema/Result/User.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::User;
 
@@ -52,8 +53,6 @@ __PACKAGE__->table("user");
   is_nullable: 0
   size: 128
 
-User's real name
-
 =head2 password
 
   data_type: 'char'
@@ -67,8 +66,6 @@ User's real name
   default_value: (empty string)
   is_nullable: 0
   size: 64
-
-Email doubles as login ID
 
 =head2 email_is_public
 
@@ -256,9 +253,10 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2015-05-10 11:16:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BBT/++Ap+7+u+Yf2VVYl0A
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:AsgYcFCVUC1KDib6dDmSDg
 
 __PACKAGE__->many_to_many('roles' => 'user_roles', 'role');
 

--- a/IFComp/lib/IFComp/Schema/Result/UserRole.pm
+++ b/IFComp/lib/IFComp/Schema/Result/UserRole.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::UserRole;
 
@@ -139,9 +140,10 @@ __PACKAGE__->belongs_to(
   },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-02-23 16:14:35
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DpV0McEN6ofgc0wtTJ5PNw
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:fZEtwmLzr+UE+A9u50kFtg
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/UserRole.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/Vote.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Vote.pm
@@ -1,3 +1,4 @@
+#<<<
 use utf8;
 package IFComp::Schema::Result::Vote;
 
@@ -173,9 +174,10 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 1, on_delete => "RESTRICT", on_update => "RESTRICT" },
 );
 
+#>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07039 @ 2014-09-06 19:19:53
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:g4UITRzNezx1Jjn4tJklmg
+# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-06-08 23:46:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3dawPRJJ6ZdRmJWk3+CNHw
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/IFComp/script/ifcomp_dump_schema.pl
+++ b/IFComp/script/ifcomp_dump_schema.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use DBIx::Class::Schema::Loader qw/make_schema_at/;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+make_schema_at(
+    'IFComp::Schema',
+    {   components              => ['InflateColumn::DateTime'],
+        dump_directory          => "$FindBin::Bin/../lib",
+        overwrite_modifications => 1,
+
+        # Add markers around generated code to avoid tidying
+        filter_generated_code => sub { return "#<<<\n$_[2]\n#>>>"; },
+    },
+    [ 'dbi:mysql:ifcomp', 'root', '' ],
+);

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ To install this project's CPAN dependencies, run the following command from the 
 
 This should crunch though the installation of a bunch of Perl modules. It'll take a few minutes.
 
+If you're planning on contributing to the project, you'll want some additional modules. Use the `--with-develop` option with the _cpanm_ command. eg.
+
+    curl -fsSL https://cpanmin.us | perl - --installdeps --with-develop .
+
 ### PHP libraries
 
 You'll need to install both PHP and the PHP MCrypt module. Both should be available through your package manager of choice. (E.g. on Debian, `sudo apt-get install php5-mcrypt` will do the trick.)


### PR DESCRIPTION
Addresses #93.

There are a few pieces here:

 * I added DBIx::Class::Schema::Loader to the cpanfile's list of develop requirements.

 * I updated the README with a note about running cpanm with the --with-develop flag to get those requirements.

 * I added a script - ifcomp_dump_schema.pl - for dumping the schema classes from the db. Most notably, it now inserts markers before and after the generated code so that perltidy won't tidy that code and screw up the checksum.

 * I dumped the schema, so all of the result classes now have those perltidy markers.

 * One side-effect of dumping the schema was that it stripped two column comments from the User class. Those comments don't get inserted by the `ifcomp_deploy_db.pl` script - only databases copied from the original (I'm guessing) will have those comments. I'd suggest removing them - otherwise we'll constantly be going back and forth removing and re-adding the comments.