### PR TITLE
Colossal fund progress-bar widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ IFComp/conf/ifcomp_local.conf
 .tidyall.d
 IFComp/entries
 IFComp/root/static/downloads
+IFComp/root/lib/config/colossal

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -1,0 +1,29 @@
+[% USE 
+   colossal_data = datafile( c.path_to( 'root/lib/config/colossal' ) )
+%]
+[% colossal = colossal_data.0 %]
+<h2>The Colossal Fund</h2>
+<p>
+Support IFComp and its authors by giving to <strong>The Colossal Fund</strong>, new for the 2017 competition! <a href="#">Learn more about it</a>.
+</p>
+        
+<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+    <input type="hidden" name="cmd" value="_s-xclick">
+    <input type="hidden" name="hosted_button_id" value="KGS6V7RPE4L34">
+    <input class="btn btn-primary center-block" type="submit" value="Donate with PayPal">
+    <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+</form>
+
+[% IF colossal.current_dollars >= colossal.goal_dollars %]
+<p class="text-center">We've reached our $[% colossal.goal_dollars %] goal! Thanks, everyone!</p>
+[% ELSE %]
+<p class="text-center">We've raised $[% colossal.current_dollars %] of our $[% colossal.goal_dollars %] goal!</p>
+[% END %]
+
+<div class="progress">
+    <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"></div>
+</div>
+
+[% IF colossal.maximum_prize > colossal.minimum_prize %]
+<p class="text-center">Current first-place prize: $[% colossal.maximum_prize %]</p>
+[% END %]

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -6,7 +6,7 @@
 
 <h2>The Colossal Fund</h2>
 <p>
-Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, which includes a new cash prize pool for top IFComp entries! <a href="#">Learn more about it</a>.
+Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, providing a new cash prize pool for top IFComp entries! <a href="#">Learn more about it</a>.
 </p>
         
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -1,6 +1,7 @@
-[% USE 
-   colossal_data = datafile( c.path_to( 'root/lib/config/colossal' ) )
-%]
+[% colossal_file = c.path_to( 'root/lib/config/colossal' ) %]
+[% TRY %]
+[% USE colossal_data = datafile( colossal_file ) %]
+
 [% colossal = colossal_data.0 %]
 <h2>The Colossal Fund</h2>
 <p>
@@ -26,4 +27,8 @@ Support IFComp and its authors by giving to <strong>The Colossal Fund</strong>, 
 
 [% IF colossal.maximum_prize > colossal.minimum_prize %]
 <p class="text-center">Current first-place prize: $[% colossal.maximum_prize %]</p>
+[% END %]
+
+[% CATCH %]
+    <div class="alert alert-danger"><p>No data file found at [% colossal_file %].</p></div>
 [% END %]

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -22,7 +22,7 @@ Support IFComp and its authors by giving to <strong>The Colossal Fund</strong>, 
 [% END %]
 
 <div class="progress">
-    <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"></div>
+    <div class="progress-bar" role="progressbar" aria-valuenow="[% colossal.current_dollars %]" aria-valuemin="0" aria-valuemax="[% colossal.goal_dollars %]" style="width: [% colossal.current_dollars / colossal.goal_dollars * 100 %]%;"></div>
 </div>
 
 [% IF colossal.maximum_prize > colossal.minimum_prize %]

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -3,9 +3,10 @@
 [% USE colossal_data = datafile( colossal_file ) %]
 
 [% colossal = colossal_data.0 %]
+
 <h2>The Colossal Fund</h2>
 <p>
-Support IFComp and its authors by giving to <strong>The Colossal Fund</strong>, new for the 2017 competition! <a href="#">Learn more about it</a>.
+Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, which includes a new cash prize pool for top IFComp entries! <a href="#">Learn more about it</a>.
 </p>
         
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
@@ -24,10 +25,6 @@ Support IFComp and its authors by giving to <strong>The Colossal Fund</strong>, 
 <div class="progress">
     <div class="progress-bar" role="progressbar" aria-valuenow="[% colossal.current_dollars %]" aria-valuemin="0" aria-valuemax="[% colossal.goal_dollars %]" style="width: [% colossal.current_dollars / colossal.goal_dollars * 100 %]%;"></div>
 </div>
-
-[% IF colossal.maximum_prize > colossal.minimum_prize %]
-<p class="text-center">Current first-place prize: $[% colossal.maximum_prize %]</p>
-[% END %]
 
 [% CATCH %]
     <div class="alert alert-danger"><p>No data file found at [% colossal_file %].</p></div>

--- a/IFComp/root/src/welcome.tt2
+++ b/IFComp/root/src/welcome.tt2
@@ -35,6 +35,12 @@
         <li>Check out <a href="[% c.uri_for('/about/prizes') %]"> the competition's prize pool</a></li>
         <li>Browse <a href="[% c.uri_for('/comp/last_comp/') %]">past IFComp entries</a></li>
     </div>
+ 
+    <div class="col-sm-4">
+     [% INCLUDE _colossal_fund.tt %]
+    </div>
+    
+
     
     <div class="col-sm-4">
         <h2>Stay comp-informed</h2>

--- a/IFComp/root/src/welcome.tt2
+++ b/IFComp/root/src/welcome.tt2
@@ -14,7 +14,7 @@
  <div class="row">
  
      <div class="col-sm-4">
-        <h2>IFComp's 23rd year!</h2>
+        <h2>IFComp's 22nd year!</h2>
         <p><strong>Welcome!</strong> Here a few things you can do on this site, right now:</p>
         <ul>
         [% IF current_comp.status == 'open_for_judging' %]

--- a/IFComp/root/src/welcome.tt2
+++ b/IFComp/root/src/welcome.tt2
@@ -14,16 +14,8 @@
  <div class="row">
  
      <div class="col-sm-4">
-        <h2>IFComp's 22nd year!</h2>
-
-        <p>
-        Welcome to IFComp.org! For a brief rundown on the IFComp and its schedule this year, see <a href="[% c.uri_for('about/comp') %]">our About the Competition page</a>.
-        </p>
-    </div>
-    
-    <div class="col-sm-4">
-        <h2>What's going on?</h2>
-        <p>A few things you can do on this site, right now:</p>
+        <h2>IFComp's 23rd year!</h2>
+        <p><strong>Welcome!</strong> Here a few things you can do on this site, right now:</p>
         <ul>
         [% IF current_comp.status == 'open_for_judging' %]
             <li><a href="[% c.uri_for('/ballot') %]">Browse and play this year's entries</a>, and then <a href="[% c.uri_for('/ballot/vote') %]">rate them</a></li>


### PR DESCRIPTION
Adds a colossal-fund widget to front page, and (since it's its own template) it's theoretically re-applicable elsewhere as well.

Expects a data file at $APP_HOME/root/lib/config/colossal. (If it's not there, it displays an error div instead of the widget.) The file format is Template Toolkit's native format for data files, because I didn't wanna either add to the controller just to read a YAML file, or repair the apparently broken TT-YAML plugin.

Example data file content:

```
goal_dollars : current_dollars : minimum_prize : maximum_prize : estimated_entries
6000 : 1200 : 10 : 123 : 60
```