### PR TITLE
Add travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+---
+sudo: false
+language: perl
+perl:
+  - "5.20.2"
+  - "5.20"
+  - "5.22"
+  - "5.24"
+  - "5.26"
+  - "dev"
+  - "blead"
+env:
+  - COVERAGE=1
+matrix:
+  allow_failures:
+    - perl: "dev"
+    - perl: "blead"
+before_install:
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  - source ~/travis-perl-helpers/init
+  - build-perl
+  - perl -V
+  - cd IFComp
+install:
+  - cpanm --notest --quiet --installdeps --with-develop .
+  - cpan-install --coverage
+before_script:
+  - coverage-setup
+script:
+  - prove -l $(test-files)
+after_success:
+  - coverage-report

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ perl:
   - "5.22"
   - "5.24"
   - "5.26"
-  - "dev"
   - "blead"
 env:
   - COVERAGE=1
 matrix:
   allow_failures:
-    - perl: "dev"
     - perl: "blead"
 before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers

--- a/IFComp/t/controller_Entry.t
+++ b/IFComp/t/controller_Entry.t
@@ -20,6 +20,7 @@ ok( my $mech =
     'Created mech object'
 );
 
+$schema->entry_directory->mkpath unless ( $schema->entry_directory->stat );
 foreach ( $schema->entry_directory->children ) {
     $_->rmtree;
 }


### PR DESCRIPTION
Adds the config for Travis-CI (and Coveralls).

Also fixes one test file - `controller_Entry.t` - to create the needed `t/entries` directory when missing.