### PR TITLE
Quixe transcripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,8 @@ sudo: false
 language: perl
 perl:
   - "5.20.2"
-  - "5.20"
-  - "5.22"
-  - "5.24"
-  - "5.26"
-  - "blead"
 env:
   - COVERAGE=1
-matrix:
-  allow_failures:
-    - perl: "blead"
 before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init

--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -28,6 +28,7 @@ requires 'HTML::FormHandler' => '0.40067';
 requires 'HTML::FormHandler::Model::DBIC';
 requires 'HTML::FormHandler::Moose';
 requires 'JSON::Any';
+requires 'JSON::XS';
 requires 'Lingua::EN::Numbers::Ordinate';
 requires 'List::Compare';
 requires 'Moose';

--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -103,12 +103,10 @@ sub transcribe : Chained('fetch_entry') : Args(0) {
     # We 'normalize' them to look like Parchment's, because it came first.
     my $data_list_ref;
     if ( $c->req->body_data->{data} ) {
-        $data_list_ref =
-            $self->_normalize_parchment_transcript_data( $c );
+        $data_list_ref = $self->_normalize_parchment_transcript_data($c);
     }
     else {
-        $data_list_ref =
-            $self->_normalize_quixe_transcript_data( $c );
+        $data_list_ref = $self->_normalize_quixe_transcript_data($c);
     }
 
     my $now = DateTime->now( time_zone => 'UTC' );
@@ -190,16 +188,15 @@ sub _normalize_quixe_transcript_data {
     my $quixe_data = $c->req->body_data;
 
     my $normalized_data = {};
-    $normalized_data->{session} = $quixe_data->{sessionId};
-    $normalized_data->{log}->{input} = $quixe_data->{input};
+    $normalized_data->{session}       = $quixe_data->{sessionId};
+    $normalized_data->{log}->{input}  = $quixe_data->{input};
     $normalized_data->{log}->{output} = $quixe_data->{output};
     $normalized_data->{log}->{window} = 0;
 
     $normalized_data->{log}->{output} =~ s/^$quixe_data->{input}//g;
 
     my $input_count = $c->model('IFCompDB::Transcript')->search(
-        {
-            entry => $c->stash->{entry}->id,
+        {   entry   => $c->stash->{entry}->id,
             session => $quixe_data->{sessionId},
         },
     )->get_column('inputcount')->max;
@@ -207,9 +204,9 @@ sub _normalize_quixe_transcript_data {
     my $output_count = ++$input_count;
 
     $normalized_data->{log}->{outputcount} = $output_count;
-    $normalized_data->{log}->{inputcount} = $input_count;
+    $normalized_data->{log}->{inputcount}  = $input_count;
 
-    return [ $normalized_data ];
+    return [$normalized_data];
 
 }
 

--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -98,17 +98,17 @@ sub transcribe : Chained('fetch_entry') : Args(0) {
 
     my $entry = $c->stash->{entry};
 
-    my $data_ref = $c->req->body_data->{data};
-    unless ( ref $data_ref ) {
-        $data_ref = from_json($data_ref);
-    }
-
+    # Quixe (natively) and Parchment (via if-recorder) report transcription
+    # data in entirely different formats.
+    # We 'normalize' them to look like Parchment's, because it came first.
     my $data_list_ref;
-    if ( ref $data_ref eq 'ARRAY' ) {
-        $data_list_ref = $data_ref;
+    if ( $c->req->body_data->{data} ) {
+        $data_list_ref =
+            $self->_normalize_parchment_transcript_data( $c );
     }
     else {
-        $data_list_ref = [$data_ref];
+        $data_list_ref =
+            $self->_normalize_quixe_transcript_data( $c );
     }
 
     my $now = DateTime->now( time_zone => 'UTC' );
@@ -162,6 +162,55 @@ sub updates : Chained('fetch_entry') : PathPart('updates') : Args(0) {
         template => 'ballot/updates.tt',
         updates  => \@updates,
     );
+}
+
+sub _normalize_parchment_transcript_data {
+    my ( $self, $c ) = @_;
+
+    my $data_ref = $c->req->body_data->{data};
+
+    unless ( ref $data_ref ) {
+        $data_ref = from_json($data_ref);
+    }
+
+    my $data_list_ref;
+    if ( ref $data_ref eq 'ARRAY' ) {
+        $data_list_ref = $data_ref;
+    }
+    else {
+        $data_list_ref = [$data_ref];
+    }
+
+    return $data_list_ref;
+}
+
+sub _normalize_quixe_transcript_data {
+    my ( $self, $c ) = @_;
+
+    my $quixe_data = $c->req->body_data;
+
+    my $normalized_data = {};
+    $normalized_data->{session} = $quixe_data->{sessionId};
+    $normalized_data->{log}->{input} = $quixe_data->{input};
+    $normalized_data->{log}->{output} = $quixe_data->{output};
+    $normalized_data->{log}->{window} = 0;
+
+    $normalized_data->{log}->{output} =~ s/^$quixe_data->{input}//g;
+
+    my $input_count = $c->model('IFCompDB::Transcript')->search(
+        {
+            entry => $c->stash->{entry}->id,
+            session => $quixe_data->{sessionId},
+        },
+    )->get_column('inputcount')->max;
+
+    my $output_count = ++$input_count;
+
+    $normalized_data->{log}->{outputcount} = $output_count;
+    $normalized_data->{log}->{inputcount} = $input_count;
+
+    return [ $normalized_data ];
+
 }
 
 1;

--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -98,16 +98,7 @@ sub transcribe : Chained('fetch_entry') : Args(0) {
 
     my $entry = $c->stash->{entry};
 
-    # Quixe (natively) and Parchment (via if-recorder) report transcription
-    # data in entirely different formats.
-    # We 'normalize' them to look like Parchment's, because it came first.
-    my $data_list_ref;
-    if ( $c->req->body_data->{data} ) {
-        $data_list_ref = $self->_normalize_parchment_transcript_data($c);
-    }
-    else {
-        $data_list_ref = $self->_normalize_quixe_transcript_data($c);
-    }
+    my $data_list_ref = $self->_normalize_transcript_data($c);
 
     my $now = DateTime->now( time_zone => 'UTC' );
     for my $transcript (@$data_list_ref) {
@@ -160,6 +151,23 @@ sub updates : Chained('fetch_entry') : PathPart('updates') : Args(0) {
         template => 'ballot/updates.tt',
         updates  => \@updates,
     );
+}
+
+sub _normalize_transcript_data {
+    my ( $self, $c ) = @_;
+
+    # Quixe (natively) and Parchment (via if-recorder) report transcription
+    # data in entirely different formats.
+    # We 'normalize' them to look like Parchment's, because it came first.
+    my $data_list_ref;
+    if ( $c->req->body_data->{data} ) {
+        $data_list_ref = $self->_normalize_parchment_transcript_data($c);
+    }
+    else {
+        $data_list_ref = $self->_normalize_quixe_transcript_data($c);
+    }
+
+    return $data_list_ref;
 }
 
 sub _normalize_parchment_transcript_data {

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -987,12 +987,12 @@ $tag_text
 <script>
 parchment_options = {
 default_story: [ "$i7_file" ],
-lib_path: '../../static/interpreter/parchment/',
+lib_path: '/static/interpreter/parchment/',
 lock_story: 1,
 page_title: 0
 };
 
-ifRecorder.saveUrl = "../../../play/$entry_id/transcribe";
+ifRecorder.saveUrl = "/play/$entry_id/transcribe";
 ifRecorder.story.name = "$title";
 ifRecorder.story.version = "1";
 </script>
@@ -1079,7 +1079,7 @@ body {
 game_options = {
   use_query_story: false,
   set_page_title: true,
-  recording_url: '../../../play/$entry_id/transcribe',
+  recording_url: '/play/$entry_id/transcribe',
   recording_label: '$title',
   recording_format: 'simple'
 };
@@ -1097,7 +1097,7 @@ game_options = {
 <hr></noscript>
 </div>
 <div id="loadingpane">
-<img src="../../static/interpreter/quixe/media/waiting.gif" alt="LOADING"><br>
+<img src="/static/interpreter/quixe/media/waiting.gif" alt="LOADING"><br>
 <em>&nbsp;&nbsp;&nbsp;Loading...</em>
 </div>
 <div id="errorpane" style="display:none;"><div id="errorcontent">...</div></div>
@@ -1146,12 +1146,12 @@ $tag_text
 <script>
 parchment_options = {
 default_story: [ "$game_file" ],
-lib_path: '../../static/interpreter/parchment/',
+lib_path: '/static/interpreter/parchment/',
 lock_story: 1,
 page_title: 0
 };
 
-ifRecorder.saveUrl = "../../../play/$entry_id/transcribe";
+ifRecorder.saveUrl = "/play/$entry_id/transcribe";
 ifRecorder.story.name = "$title";
 ifRecorder.story.version = "1";
 </script>
@@ -1183,17 +1183,17 @@ sub _mangle_quixe_head {
     # Re-aim interpreter links to our own Quixe interpreter.
     # (Via re-writing <script src="..." /> invocations.)
     $play_html =~ s{"interpreter/jquery-.*?min.js"}
-            {"../../static/interpreter/quixe/lib/jquery-1.12.4.min.js"};
+            {"/static/interpreter/quixe/lib/jquery-1.12.4.min.js"};
     $play_html =~ s{"interpreter/glkote.min.js"}
-            {"../../static/interpreter/quixe/lib/glkote.min.js"};
+            {"/static/interpreter/quixe/lib/glkote.min.js"};
     $play_html =~ s{"interpreter/quixe.min.js"}
-            {"../../static/interpreter/quixe/lib/quixe.min.js"};
+            {"/static/interpreter/quixe/lib/quixe.min.js"};
 
     # Activate transcription, aiming it at the local transcription action.
     # (Via injecting additional values into the game_options config object.)
     my $entry_id = $self->id;
     my $transcription_options =
-          "recording_url: '../../../play/$entry_id/transcribe',\n"
+          "recording_url: '/play/$entry_id/transcribe',\n"
         . "recording_format: 'simple',\n";
     $play_html =~ s[(game_options\s*=\s*{\s*)]
             [$1$transcription_options]s;
@@ -1207,20 +1207,20 @@ sub _build_interpreter_tag_text {
 
     if ( $self->is_zcode ) {
         return <<EOF;
-<script src="../../static/interpreter/parchment/jquery.min.js"></script>
-<script src="../../static/interpreter/parchment/parchment.min.js"></script>
-<script src="../../static/interpreter/transcript_recorder/if-recorder.js"></script>
-<link rel="stylesheet" type="text/css" href="../../static/interpreter/parchment/parchment.css">
-<link rel="stylesheet" type="text/css" href="../../static/interpreter/parchment/style.css">
+<script src="/static/interpreter/parchment/jquery.min.js"></script>
+<script src="/static/interpreter/parchment/parchment.min.js"></script>
+<script src="/static/interpreter/transcript_recorder/if-recorder.js"></script>
+<link rel="stylesheet" type="text/css" href="/static/interpreter/parchment/parchment.css">
+<link rel="stylesheet" type="text/css" href="/static/interpreter/parchment/style.css">
 EOF
     }
     else {
         return <<EOF;
-<script src="../../static/interpreter/quixe/lib/jquery-1.12.4.min.js"></script>
-<script src="../../static/interpreter/quixe/lib/glkote.min.js"></script>
-<script src="../../static/interpreter/quixe/lib/quixe.min.js"></script>
-<link rel="stylesheet" type="text/css" href="../../static/interpreter/quixe/media/glkote.css">
-<link rel="stylesheet" type="text/css" href="../../static/interpreter/quixe/media/dialog.css">
+<script src="/static/interpreter/quixe/lib/jquery-1.12.4.min.js"></script>
+<script src="/static/interpreter/quixe/lib/glkote.min.js"></script>
+<script src="/static/interpreter/quixe/lib/quixe.min.js"></script>
+<link rel="stylesheet" type="text/css" href="/static/interpreter/quixe/media/glkote.css">
+<link rel="stylesheet" type="text/css" href="/static/interpreter/quixe/media/dialog.css">
 EOF
     }
 }

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1181,13 +1181,26 @@ sub _mangle_quixe_head {
     my $play_html = $play_file->slurp;
 
     # Re-aim interpreter links to our own Quixe interpreter.
+    # (Via re-writing <script src="..." /> invocations.)
+    $play_html
+        =~ s{"interpreter/jquery-.*?min.js"}
+            {"../../static/interpreter/quixe/lib/jquery-1.12.4.min.js"};
+    $play_html
+        =~ s{"interpreter/glkote.min.js"}
+            {"../../static/interpreter/quixe/lib/glkote.min.js"};
+    $play_html
+        =~ s{"interpreter/quixe.min.js"}
+            {"../../static/interpreter/quixe/lib/quixe.min.js"};
 
+    # Activate transcription, aiming it at the local transcription action.
+    # (Via injecting additional values into the game_options config object.)
+    my $entry_id = $self->id;
+    my $transcription_options =
+        "recording_url: '../../../play/$entry_id/transcribe',\n"
+        . "recording_format: 'simple',\n";
     $play_html
-        =~ s{"interpreter/jquery-.*?min.js"}{"../../static/interpreter/quixe/lib/jquery-1.12.4.min.js"};
-    $play_html
-        =~ s{"interpreter/glkote.min.js"}{"../../static/interpreter/quixe/lib/glkote.min.js"};
-    $play_html
-        =~ s{"interpreter/quixe.min.js"}{"../../static/interpreter/quixe/lib/quixe.min.js"};
+        =~ s[(game_options\s*=\s*{\s*)]
+            [$1$transcription_options]s;
 
     $play_file->spew($play_html);
 

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1078,7 +1078,10 @@ body {
 <script type="text/javascript">
 game_options = {
   use_query_story: false,
-  set_page_title: true
+  set_page_title: true,
+  recording_url: '../../../play/$entry_id/transcribe',
+  recording_label: '$title',
+  recording_format: 'simple'
 };
 </script>
 

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1182,24 +1182,20 @@ sub _mangle_quixe_head {
 
     # Re-aim interpreter links to our own Quixe interpreter.
     # (Via re-writing <script src="..." /> invocations.)
-    $play_html
-        =~ s{"interpreter/jquery-.*?min.js"}
+    $play_html =~ s{"interpreter/jquery-.*?min.js"}
             {"../../static/interpreter/quixe/lib/jquery-1.12.4.min.js"};
-    $play_html
-        =~ s{"interpreter/glkote.min.js"}
+    $play_html =~ s{"interpreter/glkote.min.js"}
             {"../../static/interpreter/quixe/lib/glkote.min.js"};
-    $play_html
-        =~ s{"interpreter/quixe.min.js"}
+    $play_html =~ s{"interpreter/quixe.min.js"}
             {"../../static/interpreter/quixe/lib/quixe.min.js"};
 
     # Activate transcription, aiming it at the local transcription action.
     # (Via injecting additional values into the game_options config object.)
     my $entry_id = $self->id;
     my $transcription_options =
-        "recording_url: '../../../play/$entry_id/transcribe',\n"
+          "recording_url: '../../../play/$entry_id/transcribe',\n"
         . "recording_format: 'simple',\n";
-    $play_html
-        =~ s[(game_options\s*=\s*{\s*)]
+    $play_html =~ s[(game_options\s*=\s*{\s*)]
             [$1$transcription_options]s;
 
     $play_file->spew($play_html);

--- a/IFComp/t/controller_Play.t
+++ b/IFComp/t/controller_Play.t
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::XS;
+use FindBin;
+use Readonly;
+use lib ("$FindBin::Bin/lib");
+use Test::WWW::Mechanize::Catalyst;
+use IFCompTest;
+my $schema = IFCompTest->init_schema();
+
+ok( my $mech =
+        Test::WWW::Mechanize::Catalyst->new( catalyst_app => 'IFComp' ),
+    'Created mech object'
+);
+
+Readonly my $INPUT  => 'x me';
+Readonly my $OUTPUT => 'As good-looking as ever.';
+
+my $count = $schema->resultset('Transcript')->count;
+is( $count, 0, 'Transcription table is empty at start of test.' );
+
+IFCompTest->process_test_entries($schema);
+
+note('Testing Parchment transcription...');
+{
+    my $data = {
+        data => {
+            session => 1,
+            log     => {
+                input       => $INPUT,
+                output      => $OUTPUT,
+                window      => 0,
+                inputcount  => 1,
+                outputcount => 1,
+            },
+        },
+    };
+    my $json_data = encode_json($data);
+
+    $mech->post(
+        'http://localhost/play/100/transcribe',
+        'Content-Type' => 'application/json',
+        Content        => $json_data,
+    );
+
+    my $transcription = $schema->resultset('Transcript')->find(1);
+    is( $transcription->input,     $INPUT,  'Input recorded correctly.' );
+    is( $transcription->output,    $OUTPUT, 'Output recorded correctly.' );
+    is( $transcription->entry->id, 100,     'Entry is correct.' );
+}
+note('Testing Quixe transcription...');
+{
+    my $data = {
+        sessionId => 1,
+        input     => $INPUT,
+        output    => $OUTPUT,
+    };
+    my $json_data = encode_json($data);
+
+    $mech->post(
+        'http://localhost/play/101/transcribe',
+        'Content-Type' => 'application/json',
+        Content        => $json_data,
+    );
+
+    my $transcription = $schema->resultset('Transcript')->find(2);
+    is( $transcription->input,     $INPUT,  'Input recorded correctly.' );
+    is( $transcription->output,    $OUTPUT, 'Output recorded correctly.' );
+    is( $transcription->entry->id, 101,     'Entry is correct.' );
+}
+
+done_testing();
+

--- a/IFComp/t/entry_processing.t
+++ b/IFComp/t/entry_processing.t
@@ -9,9 +9,7 @@ my $schema = IFCompTest->init_schema();
 
 my $entry_directory = $schema->entry_directory;
 
-for my $entry ( $schema->resultset('Entry')->all ) {
-    $entry->update_content_directory;
-}
+IFCompTest->process_test_entries($schema);
 
 sub file_exists ($$) {
     my ( $entry_id, $filename ) = @_;

--- a/IFComp/t/lib/IFCompTest.pm
+++ b/IFComp/t/lib/IFCompTest.pm
@@ -111,8 +111,8 @@ sub init_schema {
     $schema->populate(
         'Entry',
         [   [ 'id', 'author', 'title',                   'comp', 'place' ],
-            [ 100,  1,        'Test Z-code game',        1,      1 ],
-            [ 101,  1,        'Test Glulx game',         1,      2 ],
+            [ 100,  1,        'Test Z-code game',        2,      1 ],
+            [ 101,  1,        'Test Glulx game',         2,      2 ],
             [ 102,  1,        'Test Quixe game',         1,      3 ],
             [ 103,  1,        'Test Parchment game',     1,      4 ],
             [ 104,  1,        'Test Z-code website',     1,      5 ],
@@ -146,6 +146,13 @@ sub log_in_as_author {
     );
 
     $mech->content_like( qr/Alice Author/, 'Login successful' );
+}
+
+sub process_test_entries {
+    my ( $class, $schema ) = @_;
+    for my $entry ( $schema->resultset('Entry')->all ) {
+        $entry->update_content_directory;
+    }
 }
 
 1;


### PR DESCRIPTION
This adds transcription-supporting configuration to the IFComp web app's quixe interpreter.

It also adds a new test for transcription, from both Parchment-style and Quixe-style sources. (It just calls the transcription action directly with some canned data, and makes sure that expected database rows have been inserted.)

Meta: This is the last PR I plan to make based on the `quixe` branch, before letting testers take the whole thing for a spin on dev. Once it meets they're approval, I'll push it all to production.