### PR TITLE
Fix typo'd closing tag.

### DIFF
--- a/IFComp/root/src/about/prizes.tt
+++ b/IFComp/root/src/about/prizes.tt
@@ -4,7 +4,7 @@
     <div class="jumbotron">
     <h1 style="text-align:center;">Prizes for the [% current_comp.year %] IFComp</h1>
     </div>
-    
+
 <p>IFComp features two kinds of prizes, both of which are <a href="#donatingprizes">donated by the IF community</a>, and then shared among the authors of top-ranked entries after the competition ends.</p>
 
 <li>
@@ -85,4 +85,4 @@
 
 <style>
 .progress { width: 50% }
-</sytle>
+</style>


### PR DESCRIPTION
The typo'd `</style>` tag was preventing the menubar from operating correctly on the /about/prizes page.