### PR TITLE
Colossal fund

### DIFF
--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -2,6 +2,7 @@ requires 'Archive::Zip';
 requires 'Cache::FastMmap';
 requires 'Catalyst::Action::RenderView';
 requires 'Catalyst::Authentication::Store::DBIx::Class', '>= 0.1506';
+requires 'Catalyst::Model::Factory';
 requires 'Catalyst::Plugin::Authentication';
 requires 'Catalyst::Plugin::Authorization::Roles';
 requires 'Catalyst::Plugin::Cache';

--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -43,6 +43,7 @@ requires 'Statistics::Basic';
 requires 'Template::Plugin::Comma';
 requires 'Template::Plugin::DateTime';
 requires 'Template::Plugin::Markdown';
+requires 'Try::Tiny';
 
 test_requires 'Test::More' => '0.88';
 test_requires 'Test::WWW::Mechanize::Catalyst';

--- a/IFComp/lib/IFComp/ColossalFund.pm
+++ b/IFComp/lib/IFComp/ColossalFund.pm
@@ -2,6 +2,7 @@ package IFComp::ColossalFund;
 
 use Moose;
 use JSON::XS;
+use Try::Tiny;
 
 use IFComp::ColossalFund::Year;
 
@@ -79,25 +80,25 @@ has 'maximum_prize' => (
 sub _build_goal {
     my $self = shift;
 
-    return $self->current_data->{ goal_dollars };
+    return $self->current_data->{ goal_dollars } || 0;
 }
 
 sub _build_estimated_entries {
     my $self = shift;
 
-    return $self->current_data->{ estimated_entries };
+    return $self->current_data->{ estimated_entries } || 0;
 }
 
 sub _build_collected {
     my $self = shift;
 
-    return $self->current_data->{ collected_dollars };
+    return $self->current_data->{ collected_dollars } || 0;
 }
 
 sub _build_minimum_prize {
     my $self = shift;
 
-    return $self->current_data->{ minimum_prize };
+    return $self->current_data->{ minimum_prize } || 0;
 }
 
 
@@ -148,7 +149,12 @@ sub _build_current_data {
         $CURRENT_DATA_FILENAME,
     );
 
-    return decode_json( $file->slurp );
+    my $data = {};
+    try {
+        $data = decode_json( $file->slurp );
+    };
+
+    return $data;
 }
 
 sub _build_maximum_prize {

--- a/IFComp/lib/IFComp/ColossalFund.pm
+++ b/IFComp/lib/IFComp/ColossalFund.pm
@@ -8,114 +8,110 @@ use IFComp::ColossalFund::Year;
 
 use Readonly;
 Readonly my $CURRENT_DATA_FILENAME => 'current_progress.json';
-Readonly my $DONORS_DIRNAME => 'contributors';
-
+Readonly my $DONORS_DIRNAME        => 'contributors';
 
 has 'data_directory' => (
     required => 1,
-    isa => 'Path::Class::Dir',
-    is => 'ro',
+    isa      => 'Path::Class::Dir',
+    is       => 'ro',
 );
 
 has 'current_data' => (
-    isa => 'HashRef',
-    is => 'ro',
+    isa        => 'HashRef',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'goal' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'estimated_entries' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'estimated_winners' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'collected' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'top_prize' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'years' => (
-    isa => 'ArrayRef[IFComp::ColossalFund::Year]',
-    is => 'ro',
+    isa        => 'ArrayRef[IFComp::ColossalFund::Year]',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'years_by_year' => (
-    isa => 'HashRef',
-    is => 'ro',
+    isa        => 'HashRef',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'minimum_prize' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 has 'maximum_prize' => (
-    isa => 'Num',
-    is => 'ro',
+    isa        => 'Num',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 sub _build_goal {
     my $self = shift;
 
-    return $self->current_data->{ goal_dollars } || 0;
+    return $self->current_data->{goal_dollars} || 0;
 }
 
 sub _build_estimated_entries {
     my $self = shift;
 
-    return $self->current_data->{ estimated_entries } || 0;
+    return $self->current_data->{estimated_entries} || 0;
 }
 
 sub _build_collected {
     my $self = shift;
 
-    return $self->current_data->{ collected_dollars } || 0;
+    return $self->current_data->{collected_dollars} || 0;
 }
 
 sub _build_minimum_prize {
     my $self = shift;
 
-    return $self->current_data->{ minimum_prize } || 0;
+    return $self->current_data->{minimum_prize} || 0;
 }
-
 
 sub _build_years {
     my $self = shift;
 
     my @years;
 
-    my $donor_dir = Path::Class::Dir->new(
-        $self->data_directory,
-        $DONORS_DIRNAME,
-    );
+    my $donor_dir =
+        Path::Class::Dir->new( $self->data_directory, $DONORS_DIRNAME, );
 
     for my $file ( $donor_dir->children ) {
         if ( $file =~ /csv$/ ) {
             push @years,
-                 IFComp::ColossalFund::Year->new( data_file => $file );
+                IFComp::ColossalFund::Year->new( data_file => $file );
         }
     }
 
@@ -144,10 +140,8 @@ sub _build_estimated_winners {
 sub _build_current_data {
     my $self = shift;
 
-    my $file = Path::Class::File->new(
-        $self->data_directory,
-        $CURRENT_DATA_FILENAME,
-    );
+    my $file = Path::Class::File->new( $self->data_directory,
+        $CURRENT_DATA_FILENAME, );
 
     my $data = {};
     try {
@@ -161,13 +155,14 @@ sub _build_maximum_prize {
     my $self = shift;
 
     my $maximum;
-    unless ( $maximum = $self->current_data->{ maximum_prize } ) {
+    unless ( $maximum = $self->current_data->{maximum_prize} ) {
+
         # XXX This doesn't work. Please just set it in the data for now. :b
-        my $pool = $self->collected * 0.8;
+        my $pool    = $self->collected * 0.8;
         my $winners = $self->estimated_winners;
         my $minimum = $self->minimum_prize;
-        my $temp = 3 * ( $pool - $minimum * $winners ) / $winners;
-        $maximum = $temp * (((.5 / $winners) - 1) ^ 2) + $minimum;
+        my $temp    = 3 * ( $pool - $minimum * $winners ) / $winners;
+        $maximum = $temp * ( ( ( .5 / $winners ) - 1 ) ^ 2 ) + $minimum;
     }
 
     return $maximum;
@@ -176,7 +171,7 @@ sub _build_maximum_prize {
 sub year {
     my ( $self, $year ) = @_;
 
-    return $self->years_by_year->{ $year };
+    return $self->years_by_year->{$year};
 }
 
 1;

--- a/IFComp/lib/IFComp/ColossalFund.pm
+++ b/IFComp/lib/IFComp/ColossalFund.pm
@@ -64,6 +64,18 @@ has 'years_by_year' => (
     lazy_build => 1,
 );
 
+has 'minimum_prize' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'maximum_prize' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
 sub _build_goal {
     my $self = shift;
 
@@ -139,10 +151,20 @@ sub _build_current_data {
     return decode_json( $file->slurp );
 }
 
-sub _buld_maximum_prize {
+sub _build_maximum_prize {
     my $self = shift;
 
-    return (3*($self->collected-$self->minimum_prize*$self->estimated_winners)/$self->estimated_winners)*(((.5/$self->estimated_winners)-1)^2)+$self->minimum_prize;
+    my $maximum;
+    unless ( $maximum = $self->current_data->{ maximum_prize } ) {
+        # XXX This doesn't work. Please just set it in the data for now. :b
+        my $pool = $self->collected * 0.8;
+        my $winners = $self->estimated_winners;
+        my $minimum = $self->minimum_prize;
+        my $temp = 3 * ( $pool - $minimum * $winners ) / $winners;
+        $maximum = $temp * (((.5 / $winners) - 1) ^ 2) + $minimum;
+    }
+
+    return $maximum;
 }
 
 sub year {

--- a/IFComp/lib/IFComp/ColossalFund.pm
+++ b/IFComp/lib/IFComp/ColossalFund.pm
@@ -1,0 +1,133 @@
+package IFComp::ColossalFund;
+
+use Moose;
+use JSON::XS;
+
+use IFComp::ColossalFund::Year;
+
+use Readonly;
+Readonly my $CURRENT_DATA_FILENAME => 'current_progress.json';
+Readonly my $DONORS_DIRNAME => 'contributors';
+
+
+has 'data_directory' => (
+    required => 1,
+    isa => 'Path::Class::Dir',
+    is => 'ro',
+);
+
+has 'current_data' => (
+    isa => 'HashRef',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'goal' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'estimated_entries' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'estimated_winners' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'collected' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'top_prize' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'years' => (
+    isa => 'ArrayRef[IFComp::ColossalFund::Year]',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+sub _build_goal {
+    my $self = shift;
+
+    return $self->current_data->{ goal_dollars };
+}
+
+sub _build_estimated_entries {
+    my $self = shift;
+
+    return $self->current_data->{ estimated_entries };
+}
+
+sub _build_collected {
+    my $self = shift;
+
+    return $self->current_data->{ collected_dollars };
+}
+
+sub _build_minimum_prize {
+    my $self = shift;
+
+    return $self->current_data->{ minimum_prize };
+}
+
+
+sub _build_years {
+    my $self = shift;
+
+    my @years;
+
+    my $donor_dir = Path::Class::Dir->new(
+        $self->data_directory,
+        $DONORS_DIRNAME,
+    );
+
+    for my $file ( $donor_dir->children ) {
+        if ( $file =~ /csv$/ ) {
+            push @years,
+                 IFComp::ColossalFund::Year->new( data_file => $file );
+        }
+    }
+
+    return \@years;
+
+}
+
+sub _build_estimated_winners {
+    my $self = shift;
+
+    return int( $self->estimated_entries * .6667 + 0.5 );
+}
+
+sub _build_current_data {
+    my $self = shift;
+
+    my $file = Path::Class::File->new(
+        $self->data_directory,
+        $CURRENT_DATA_FILENAME,
+    );
+
+    return decode_json( $file->slurp );
+}
+
+sub _buld_maximum_prize {
+    my $self = shift;
+
+    return (3*($self->collected-$self->minimum_prize*$self->estimated_winners)/$self->estimated_winners)*(((.5/$self->estimated_winners)-1)^2)+$self->minimum_prize;
+}
+
+
+
+1;
+

--- a/IFComp/lib/IFComp/ColossalFund.pm
+++ b/IFComp/lib/IFComp/ColossalFund.pm
@@ -58,6 +58,12 @@ has 'years' => (
     lazy_build => 1,
 );
 
+has 'years_by_year' => (
+    isa => 'HashRef',
+    is => 'ro',
+    lazy_build => 1,
+);
+
 sub _build_goal {
     my $self = shift;
 
@@ -104,6 +110,18 @@ sub _build_years {
 
 }
 
+sub _build_years_by_year {
+    my $self = shift;
+
+    my %years_by_year;
+
+    for my $year ( @{ $self->years } ) {
+        $years_by_year{ $year->year } = $year;
+    }
+
+    return \%years_by_year;
+}
+
 sub _build_estimated_winners {
     my $self = shift;
 
@@ -127,7 +145,11 @@ sub _buld_maximum_prize {
     return (3*($self->collected-$self->minimum_prize*$self->estimated_winners)/$self->estimated_winners)*(((.5/$self->estimated_winners)-1)^2)+$self->minimum_prize;
 }
 
+sub year {
+    my ( $self, $year ) = @_;
 
+    return $self->years_by_year->{ $year };
+}
 
 1;
 

--- a/IFComp/lib/IFComp/ColossalFund/Donor.pm
+++ b/IFComp/lib/IFComp/ColossalFund/Donor.pm
@@ -15,7 +15,7 @@ has 'name' => (
 );
 
 has 'email' => (
-    isa => 'Str',
+    isa => 'Maybe[Str]',
     is => 'ro',
     required => 1,
 );

--- a/IFComp/lib/IFComp/ColossalFund/Donor.pm
+++ b/IFComp/lib/IFComp/ColossalFund/Donor.pm
@@ -20,11 +20,27 @@ has 'email' => (
     required => 1,
 );
 
-has 'permission_to_name' => (
+has 'is_anonymous' => (
     isa => 'Bool',
     is => 'ro',
-    default => 0,
+    lazy_build => 1,
 );
+
+sub _build_is_anonymous {
+    my $self = shift;
+
+    my $name = lc($self->name);
+
+    # I'm not sure how all this whitespace is getting stuck onto the name.
+    $name =~ s/\s*$//;
+
+    if (!$name || $name eq 'anonymous') {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
 
 1;
 

--- a/IFComp/lib/IFComp/ColossalFund/Donor.pm
+++ b/IFComp/lib/IFComp/ColossalFund/Donor.pm
@@ -1,0 +1,30 @@
+package IFComp::ColossalFund::Donor;
+
+use Moose;
+
+has 'donation' => (
+    isa => 'Num',
+    is => 'rw',
+    required => 1,
+);
+
+has 'name' => (
+    isa => 'Str',
+    is => 'ro',
+    required => 1,
+);
+
+has 'email' => (
+    isa => 'Str',
+    is => 'ro',
+    required => 1,
+);
+
+has 'permission_to_name' => (
+    isa => 'Bool',
+    is => 'ro',
+    default => 0,
+);
+
+1;
+

--- a/IFComp/lib/IFComp/ColossalFund/Donor.pm
+++ b/IFComp/lib/IFComp/ColossalFund/Donor.pm
@@ -3,38 +3,38 @@ package IFComp::ColossalFund::Donor;
 use Moose;
 
 has 'donation' => (
-    isa => 'Num',
-    is => 'rw',
+    isa      => 'Num',
+    is       => 'rw',
     required => 1,
 );
 
 has 'name' => (
-    isa => 'Str',
-    is => 'ro',
+    isa      => 'Str',
+    is       => 'ro',
     required => 1,
 );
 
 has 'email' => (
-    isa => 'Maybe[Str]',
-    is => 'ro',
+    isa      => 'Maybe[Str]',
+    is       => 'ro',
     required => 1,
 );
 
 has 'is_anonymous' => (
-    isa => 'Bool',
-    is => 'ro',
+    isa        => 'Bool',
+    is         => 'ro',
     lazy_build => 1,
 );
 
 sub _build_is_anonymous {
     my $self = shift;
 
-    my $name = lc($self->name);
+    my $name = lc( $self->name );
 
     # I'm not sure how all this whitespace is getting stuck onto the name.
     $name =~ s/\s*$//;
 
-    if (!$name || $name eq 'anonymous') {
+    if ( !$name || $name eq 'anonymous' ) {
         return 1;
     }
     else {

--- a/IFComp/lib/IFComp/ColossalFund/Year.pm
+++ b/IFComp/lib/IFComp/ColossalFund/Year.pm
@@ -1,0 +1,106 @@
+package IFComp::ColossalFund::Year;
+
+use Moose;
+use IFComp::ColossalFund::Donor;
+
+has 'data_file' => (
+    isa => 'Path::Class::File',
+    is => 'ro',
+    required => 1,
+);
+
+has 'year' => (
+    isa => 'Num',
+    is => 'ro',
+    lazy_build => 1,
+);
+
+has 'donors' => (
+    isa => 'ArrayRef[IFComp::ColossalFund::Donor]',
+    is => 'rw',
+    default => sub { [] },
+);
+
+sub _build_year {
+    my $self = shift;
+
+    # The year is just the data file's filename.
+    my ( $year ) = $self->data_file =~ /^(\d+)/;
+
+    return $year;
+}
+
+sub BUILD {
+    my $self = shift;
+
+    my @lines = $self->data_file->slurp(
+        chomp => 1,
+        split => qr/\s*,\s*/,
+        iomode => '<:encoding(UTF-8)',
+    );
+
+    # The CSV might contain multiple donations from the same person, as
+    # identified by email address, so we'll flatten em out first.
+    my %donors_by_email;
+
+    for my $line ( @lines ) {
+        my ($date, $gross, $net, $name, $email, $permission) = @$line;
+        next unless $date =~ /\d/;
+
+        foreach ( $gross, $net ) {
+            s/^\s*\$//;
+        }
+
+        unless ( $donors_by_email{ $email } ) {
+            $donors_by_email{ $email } = {
+                donation => 0,
+                name => $name,
+                email => $email,
+                permission_to_name => $permission,
+            };
+        }
+
+        $donors_by_email{ $email }->{ donation } += $gross;
+    }
+
+    # Now sort the donors by donation, and make our donors from that.
+    my @donor_data = values %donors_by_email;
+    @donor_data = sort { $a->{donation} <=> $b->{donation} } @donor_data;
+    @donor_data = map { IFComp::ColossalFund::Donor->new( $_ ) } @donor_data;
+
+    $self->donors( \@donor_data );
+
+}
+
+sub named_donors_between {
+    my $self = shift;
+    my ( $min, $max ) = @_;
+
+    return $self->_donors_between( $min, $max, 1 );
+}
+
+sub anonymous_donors_between {
+    my $self = shift;
+    my ( $min, $max ) = @_;
+
+    return $self->_donors_between( $min, $max, 0 );
+}
+
+sub _donors_between {
+    my $self = shift;
+    my ( $min, $max, $permission ) = @_;
+
+    my @donors;
+    for my $donor ( @{ $self->donors} ) {
+        if (
+            ( $donor->donation >= $min )
+            && ( not( defined $max ) || $donor->donation <= $max )
+            && ( $donor->permission_to_name == $permission )
+        ) {
+            push @donors, $donor;
+        }
+    }
+    return @donors;
+}
+
+1;

--- a/IFComp/lib/IFComp/Controller/About.pm
+++ b/IFComp/lib/IFComp/Controller/About.pm
@@ -77,6 +77,7 @@ sub prizes : Path('prizes') : Args(0) {
     }
 
     $c->stash->{prizes_in_category} = \%prizes_in_category;
+    $c->stash->{cf} = $c->model('ColossalFund');
 
 }
 
@@ -95,8 +96,10 @@ sub colossal_fund : Path('colossal') {
     my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
     $year ||= $current_comp->year;
 
-    my $cf = $c->model('ColossalFund')->year( $year );
-    unless ( $cf ) {
+    my $cf = $c->model('ColossalFund');
+    my $cf_year = $cf->year( $year );
+
+    unless ( $cf_year ) {
         $c->detach( '/error_404' );
         return;
     }
@@ -104,6 +107,7 @@ sub colossal_fund : Path('colossal') {
     $c->stash(
         current_comp => $current_comp,
         cf           => $cf,
+        cf_year      => $cf_year,
     );
 }
 

--- a/IFComp/lib/IFComp/Controller/About.pm
+++ b/IFComp/lib/IFComp/Controller/About.pm
@@ -89,6 +89,24 @@ sub faq : Path('faq') : Args(0) {
 sub copyright : Path('copyright') : Args(0) {
 }
 
+sub colossal_fund : Path('colossal') {
+    my ( $self, $c, $year ) = @_;
+
+    my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
+    $year ||= $current_comp->year;
+
+    my $cf = $c->model('ColossalFund')->year( $year );
+    unless ( $cf ) {
+        $c->detach( '/error_404' );
+        return;
+    }
+
+    $c->stash(
+        current_comp => $current_comp,
+        cf           => $cf,
+    );
+}
+
 =encoding utf8
 
 =head1 AUTHOR

--- a/IFComp/lib/IFComp/Controller/About.pm
+++ b/IFComp/lib/IFComp/Controller/About.pm
@@ -77,7 +77,7 @@ sub prizes : Path('prizes') : Args(0) {
     }
 
     $c->stash->{prizes_in_category} = \%prizes_in_category;
-    $c->stash->{cf} = $c->model('ColossalFund');
+    $c->stash->{cf}                 = $c->model('ColossalFund');
 
 }
 
@@ -96,11 +96,11 @@ sub colossal_fund : Path('colossal') {
     my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
     $year ||= $current_comp->year;
 
-    my $cf = $c->model('ColossalFund');
-    my $cf_year = $cf->year( $year );
+    my $cf      = $c->model('ColossalFund');
+    my $cf_year = $cf->year($year);
 
-    unless ( $cf_year ) {
-        $c->detach( '/error_404' );
+    unless ($cf_year) {
+        $c->detach('/error_404');
         return;
     }
 

--- a/IFComp/lib/IFComp/Controller/Root.pm
+++ b/IFComp/lib/IFComp/Controller/Root.pm
@@ -31,7 +31,7 @@ The root page (/)
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
     $c->stash->{template} = 'welcome.tt2';
-    $c->stash->{cf} = $c->model('ColossalFund');
+    $c->stash->{cf}       = $c->model('ColossalFund');
 }
 
 =head2 default

--- a/IFComp/lib/IFComp/Controller/Root.pm
+++ b/IFComp/lib/IFComp/Controller/Root.pm
@@ -31,6 +31,7 @@ The root page (/)
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
     $c->stash->{template} = 'welcome.tt2';
+    $c->stash->{cf} = $c->model('ColossalFund');
 }
 
 =head2 default

--- a/IFComp/lib/IFComp/Model/ColossalFund.pm
+++ b/IFComp/lib/IFComp/Model/ColossalFund.pm
@@ -1,0 +1,21 @@
+package IFComp::Model::ColossalFund;
+use Moose;
+use namespace::autoclean;
+
+extends 'Catalyst::Model::Adaptor';
+
+__PACKAGE__->config(
+    class => 'IFComp::ColossalFund',
+);
+
+sub prepare_arguments {
+    my ( $self, $c ) = @_;
+
+    return {
+        data_directory => $c->path_to( '/root/lib/data/colossal_fund' )
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/IFComp/lib/IFComp/Model/ColossalFund.pm
+++ b/IFComp/lib/IFComp/Model/ColossalFund.pm
@@ -2,7 +2,7 @@ package IFComp::Model::ColossalFund;
 use Moose;
 use namespace::autoclean;
 
-extends 'Catalyst::Model::Adaptor';
+extends 'Catalyst::Model::Factory';
 
 __PACKAGE__->config(
     class => 'IFComp::ColossalFund',

--- a/IFComp/lib/IFComp/Model/ColossalFund.pm
+++ b/IFComp/lib/IFComp/Model/ColossalFund.pm
@@ -4,16 +4,12 @@ use namespace::autoclean;
 
 extends 'Catalyst::Model::Factory';
 
-__PACKAGE__->config(
-    class => 'IFComp::ColossalFund',
-);
+__PACKAGE__->config( class => 'IFComp::ColossalFund', );
 
 sub prepare_arguments {
     my ( $self, $c ) = @_;
 
-    return {
-        data_directory => $c->path_to( '/root/lib/data/colossal_fund' )
-    };
+    return { data_directory => $c->path_to('/root/lib/data/colossal_fund') };
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/IFComp/lib/IFComp/Model/ColossalFund.pm
+++ b/IFComp/lib/IFComp/Model/ColossalFund.pm
@@ -13,7 +13,7 @@ sub prepare_arguments {
 
     return {
         data_directory => Path::Class::Dir->new(
-            $c->path_to( '/root/lib/data/colossal_fund' )
+            $c->path_to('/root/lib/data/colossal_fund')
         )
     };
 }

--- a/IFComp/lib/IFComp/Model/ColossalFund.pm
+++ b/IFComp/lib/IFComp/Model/ColossalFund.pm
@@ -2,6 +2,8 @@ package IFComp::Model::ColossalFund;
 use Moose;
 use namespace::autoclean;
 
+use Path::Class::File;
+
 extends 'Catalyst::Model::Factory';
 
 __PACKAGE__->config( class => 'IFComp::ColossalFund', );
@@ -9,7 +11,11 @@ __PACKAGE__->config( class => 'IFComp::ColossalFund', );
 sub prepare_arguments {
     my ( $self, $c ) = @_;
 
-    return { data_directory => $c->path_to('/root/lib/data/colossal_fund') };
+    return {
+        data_directory => Path::Class::Dir->new(
+            $c->path_to( '/root/lib/data/colossal_fund' )
+        )
+    };
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -10,6 +10,8 @@ Support IFComp and its authors through a charitable gift to <strong>The Colossal
     <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 </form>
 
+[% IF cf.goal %]
+
 [% IF cf.collected >= cf.goal %]
 <p class="text-center">We've reached our $[% cf.goal %] goal! Thanks, everyone!</p>
 [% ELSE %]
@@ -22,4 +24,6 @@ Support IFComp and its authors through a charitable gift to <strong>The Colossal
 
 [% IF show_maximum_prize %]
 <p class="text-center">At the current donation level, the first-place IFComp entry will receive <strong>$[% cf.maximum_prize %]</strong> (assuming [% cf.estimated_entries %] entries).</p>
+[% END %]
+
 [% END %]

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -1,6 +1,6 @@
 <h2 id="colossal-fund">The Colossal Fund</h2>
 <p>
-Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, providing a new cash prize pool for top IFComp entries! <a href="http://blog.ifcomp.org/post/162478013529/announcing-the-ifcomp-colossal-fund">Learn more about it</a>.
+Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, providing a new cash prize pool for top IFComp entries! <a href="http://blog.ifcomp.org/post/162478013529/announcing-the-ifcomp-colossal-fund">Learn more about it</a>, and <a href="/about/colossal/">see who has contributed this year</a>.
 </p>
         
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">

--- a/IFComp/root/src/_colossal_fund.tt
+++ b/IFComp/root/src/_colossal_fund.tt
@@ -1,9 +1,3 @@
-[% colossal_file = c.path_to( 'root/lib/config/colossal' ) %]
-[% TRY %]
-[% USE colossal_data = datafile( colossal_file ) %]
-
-[% colossal = colossal_data.0 %]
-
 <h2 id="colossal-fund">The Colossal Fund</h2>
 <p>
 Support IFComp and its authors through a charitable gift to <strong>The Colossal Fund</strong>, providing a new cash prize pool for top IFComp entries! <a href="http://blog.ifcomp.org/post/162478013529/announcing-the-ifcomp-colossal-fund">Learn more about it</a>.
@@ -16,20 +10,16 @@ Support IFComp and its authors through a charitable gift to <strong>The Colossal
     <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 </form>
 
-[% IF colossal.current_dollars >= colossal.goal_dollars %]
-<p class="text-center">We've reached our $[% colossal.goal_dollars %] goal! Thanks, everyone!</p>
+[% IF cf.collected >= cf.goal %]
+<p class="text-center">We've reached our $[% cf.goal %] goal! Thanks, everyone!</p>
 [% ELSE %]
-<p class="text-center">We've raised $[% colossal.current_dollars %] of our $[% colossal.goal_dollars %] goal!</p>
+<p class="text-center">We've raised $[% cf.collected %] of our $[% cf.goal %] goal!</p>
 [% END %]
 
 <div class="progress center-block">
-    <div class="progress-bar" role="progressbar" aria-valuenow="[% colossal.current_dollars %]" aria-valuemin="0" aria-valuemax="[% colossal.goal_dollars %]" style="width: [% colossal.current_dollars / colossal.goal_dollars * 100 %]%;"></div>
+    <div class="progress-bar" role="progressbar" aria-valuenow="[% cf.collected %]" aria-valuemin="0" aria-valuemax="[% cf.goal %]" style="width: [% cf.collected / cf.goal * 100 %]%;"></div>
 </div>
 
 [% IF show_maximum_prize %]
-<p class="text-center">At the current donation level, the first-place IFComp entry will receive <strong>$[% colossal.maximum_prize %]</strong> (assuming [% colossal.estimated_entries %] entries).</p>
-[% END %]
-
-[% CATCH %]
-    <div class="alert alert-danger"><p>No data file found at [% colossal_file %].</p></div>
+<p class="text-center">At the current donation level, the first-place IFComp entry will receive <strong>$[% cf.maximum_prize %]</strong> (assuming [% cf.estimated_entries %] entries).</p>
 [% END %]

--- a/IFComp/root/src/about/colossal_fund.tt
+++ b/IFComp/root/src/about/colossal_fund.tt
@@ -1,0 +1,33 @@
+<div class="container">
+<div class="jumbotron">
+<h1 style="text-align:center;">Colossal Fund Donors: [% cf.year %]</h1>
+</div>
+
+[% INCLUDE level name = 'platinum bar',   min = 1000, max = undef %]
+[% INCLUDE level name = 'pot of gold',    min = 500,  max = 999 %]
+[% INCLUDE level name = 'silver chalice', min = 100,  max = 499 %]
+[% INCLUDE level name = 'jade figurine',  min = 50,   max = 99 %]
+[% INCLUDE level name = 'brass bauble',   min = 0,    max = 49 %]
+
+[% BLOCK level %]
+    <div class="level">
+    <h2> [% name.ucfirst %] donors </h2>
+    [% named_donors = year.named_donors_between( min, max ) %]
+    [% anonymous_donors = year.anonymous_donors_between( min, max ) %]
+    [% IF named_donors.size %]
+        I see [% named_donors.size %]
+        <ul>
+        [% FOREACH donor IN named_donors %]
+            <li>[% donor.name %]</li>
+        [% END %]
+        </ul>
+        [% IF anonymous_donors.size %]
+            <p>Plus [% anonymous_donors.size %] anonymous adventurers.</p>
+        [% END %]
+    [% ELSIF anonymous_donors.size %]
+        <p>[% anonymous_donors.size %] anonymous adventurers.</p>
+    [% ELSE %]
+        <p><em>No donors at this level [% IF cf.year == current_comp.year %](yet...)[% END %]</em></p>
+    [% END %]
+    </div>
+[% END %]

--- a/IFComp/root/src/about/colossal_fund.tt
+++ b/IFComp/root/src/about/colossal_fund.tt
@@ -3,16 +3,19 @@
 <h1 style="text-align:center;">Colossal Fund Donors: [% cf_year.year %]</h1>
 </div>
 
+<p>
+The following IF community members supported IFComp through their contributions to [% cf_year.year %]'s Colossal Fund. We salute their generosity!
+</p>
+
 [% INCLUDE level name = 'platinum bar',   min = 1000, max = undef %]
 [% INCLUDE level name = 'pot of gold',    min = 500,  max = 999 %]
 [% INCLUDE level name = 'silver chalice', min = 100,  max = 499 %]
 [% INCLUDE level name = 'jade figurine',  min = 50,   max = 99 %]
-[% INCLUDE level name = 'brass bauble',   min = 0,    max = 49 %]
+[% INCLUDE level name = 'brass bauble',   min = 1,    max = 49 %]
 
 [% BLOCK level %]
     <div class="level">
-    <h2> [% name.ucfirst %] donors </h2>
-    <p>Contributed [% IF max %]between $[% min %] and $[% max %][% ELSE %]$[% min %] or more[% END %]:</p>
+    <h2> [% name.ucfirst %] donors <span class="small">(contributed [% IF max %]between $[% min %] and $[% max %][% ELSE %]$[% min %] or more[% END %])</span></h2>
     [% named_donors = cf_year.named_donors_between( min, max ) %]
     [% anonymous_donors = cf_year.anonymous_donors_between( min, max ) %]
     [% IF named_donors.size %]

--- a/IFComp/root/src/about/colossal_fund.tt
+++ b/IFComp/root/src/about/colossal_fund.tt
@@ -1,6 +1,6 @@
 <div class="container">
 <div class="jumbotron">
-<h1 style="text-align:center;">Colossal Fund Donors: [% cf.year %]</h1>
+<h1 style="text-align:center;">Colossal Fund Donors: [% cf_year.year %]</h1>
 </div>
 
 [% INCLUDE level name = 'platinum bar',   min = 1000, max = undef %]
@@ -12,17 +12,17 @@
 [% BLOCK level %]
     <div class="level">
     <h2> [% name.ucfirst %] donors </h2>
-    [% named_donors = year.named_donors_between( min, max ) %]
-    [% anonymous_donors = year.anonymous_donors_between( min, max ) %]
+    <p>Contributed [% IF max %]between $[% min %] and $[% max %][% ELSE %]$[% min %] or more[% END %]:</p>
+    [% named_donors = cf_year.named_donors_between( min, max ) %]
+    [% anonymous_donors = cf_year.anonymous_donors_between( min, max ) %]
     [% IF named_donors.size %]
-        I see [% named_donors.size %]
         <ul>
         [% FOREACH donor IN named_donors %]
             <li>[% donor.name %]</li>
         [% END %]
         </ul>
         [% IF anonymous_donors.size %]
-            <p>Plus [% anonymous_donors.size %] anonymous adventurers.</p>
+            <p>...as well as [% anonymous_donors.size %] anonymous adventurers.</p>
         [% END %]
     [% ELSIF anonymous_donors.size %]
         <p>[% anonymous_donors.size %] anonymous adventurers.</p>
@@ -31,3 +31,5 @@
     [% END %]
     </div>
 [% END %]
+
+[% INCLUDE _colossal_fund.tt show_maximum_prize = 1 %]

--- a/IFComp/t/colossal/contributors/1999.csv
+++ b/IFComp/t/colossal/contributors/1999.csv
@@ -1,0 +1,6 @@
+Date,Donation,After Fees,Name,Email,Permission
+07/01/1999,$100.00,$97.50,Alice Nobody,alice@example.com,1
+07/01/2000,$100.00,$97.50,Esther Nobody,esther@example.com,1
+07/01/1999,$100.00,$97.50,Bob Aliceson,bob@example.com,1
+07/01/1999,$50.00,$48.60,Carol Whodat,carol@example.com,0
+08/01/1999,$50.00,$48.60,Hey it's Alice Again,alice@example.com,0

--- a/IFComp/t/colossal/contributors/1999.csv
+++ b/IFComp/t/colossal/contributors/1999.csv
@@ -1,6 +1,5 @@
-Date,Donation,After Fees,Name,Email,Permission
-07/01/1999,$100.00,$97.50,Alice Nobody,alice@example.com,1
-07/01/2000,$100.00,$97.50,Esther Nobody,esther@example.com,1
-07/01/1999,$100.00,$97.50,Bob Aliceson,bob@example.com,1
-07/01/1999,$50.00,$48.60,Carol Whodat,carol@example.com,0
-08/01/1999,$50.00,$48.60,Hey it's Alice Again,alice@example.com,0
+alice@example.com,$100,Alice
+esther@example.com,$100,Esther
+bob@example.com,$100,Bob
+carol@example.com,$50,Anonymous
+alice@example.com,$50,Alice Again

--- a/IFComp/t/colossal/contributors/2000.csv
+++ b/IFComp/t/colossal/contributors/2000.csv
@@ -1,0 +1,6 @@
+Date,Donation,After Fees,Name,Email,Permission
+07/01/2000,$100.00,$97.50,Alice Nobody,alice@example.com,1
+07/01/2000,$100.00,$97.50,Esther Nobody,esther@example.com,1
+07/01/2000,$100.00,$97.50,Bob Aliceson,bob@example.com,1
+07/01/2000,$50.00,$48.60,Carol Whodat,carol@example.com,0
+08/01/2000,$50.00,$48.60,Hey it's Alice Again,alice@example.com,0

--- a/IFComp/t/colossal/contributors/2000.csv
+++ b/IFComp/t/colossal/contributors/2000.csv
@@ -1,6 +1,5 @@
-Date,Donation,After Fees,Name,Email,Permission
-07/01/2000,$100.00,$97.50,Alice Nobody,alice@example.com,1
-07/01/2000,$100.00,$97.50,Esther Nobody,esther@example.com,1
-07/01/2000,$100.00,$97.50,Bob Aliceson,bob@example.com,1
-07/01/2000,$50.00,$48.60,Carol Whodat,carol@example.com,0
-08/01/2000,$50.00,$48.60,Hey it's Alice Again,alice@example.com,0
+alice@example.com,$100,Alice
+esther@example.com,$100,Esther
+bob@example.com,$100,Bob
+carol@example.com,$50,Anonymous
+alice@example.com,$50,Alice Again

--- a/IFComp/t/colossal/current_progress.json
+++ b/IFComp/t/colossal/current_progress.json
@@ -1,0 +1,6 @@
+{
+    "goal_dollars": 6000,
+    "collected_dollars": 1200,
+    "minimum_prize": 10,
+    "estimated_entries": 60
+}

--- a/IFComp/t/colossal/current_progress.json
+++ b/IFComp/t/colossal/current_progress.json
@@ -1,6 +1,7 @@
 {
     "goal_dollars": 6000,
-    "collected_dollars": 1200,
+    "collected_dollars": 4521,
     "minimum_prize": 10,
+    "maximum_prize": 245,
     "estimated_entries": 60
 }

--- a/IFComp/t/colossal_fund.t
+++ b/IFComp/t/colossal_fund.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+
+use FindBin;
+use lib ("$FindBin::Bin/lib");
+
+use Path::Class::Dir;
+
+use IFComp::ColossalFund;
+
+my $cf_data_dir = Path::Class::Dir->new(
+    "$FindBin::Bin/colossal"
+);
+
+my $cf = IFComp::ColossalFund->new( {
+    data_directory => $cf_data_dir,
+} );
+
+is( $cf->collected, 1200 );
+is( @{ $cf->years }, 2, 'Current collected amount' );
+
+my $year = $cf->years->[0];
+is( @{ $year->donors }, 4, 'Total donors' );
+
+my @named_small_donors = $year->named_donors_between( 0, 100 );
+is (@named_small_donors, 2, 'Small donors', );
+
+my @anonymous_small_donors = $year->anonymous_donors_between( 0, 100 );
+is (@anonymous_small_donors, 1, 'Small anonymous donors', );
+
+my @named_big_donors = $year->named_donors_between( 101, undef );
+is (@named_big_donors, 1, 'Big donors',);
+
+done_testing();

--- a/IFComp/t/colossal_fund.t
+++ b/IFComp/t/colossal_fund.t
@@ -9,7 +9,7 @@ use Path::Class::Dir;
 
 use IFComp::ColossalFund;
 
-my $cf_data_dir = Path::Class::Dir->new( "$FindBin::Bin/colossal" );
+my $cf_data_dir = Path::Class::Dir->new("$FindBin::Bin/colossal");
 
 my $cf = IFComp::ColossalFund->new( { data_directory => $cf_data_dir, } );
 

--- a/IFComp/t/colossal_fund.t
+++ b/IFComp/t/colossal_fund.t
@@ -17,19 +17,21 @@ my $cf = IFComp::ColossalFund->new( {
     data_directory => $cf_data_dir,
 } );
 
-is( $cf->collected, 1200 );
+is( $cf->collected, 4521 );
 is( @{ $cf->years }, 2, 'Current collected amount' );
+
+is( $cf->maximum_prize, 245, 'Maximum prize' );
 
 my $year = $cf->years->[0];
 is( @{ $year->donors }, 4, 'Total donors' );
 
-my @named_small_donors = $year->named_donors_between( 0, 100 );
-is (@named_small_donors, 2, 'Small donors', );
+my @named_small_donors = @{$year->named_donors_between( 0, 100 )};
+is (@named_small_donors, 2, 'Small named donors', );
 
-my @anonymous_small_donors = $year->anonymous_donors_between( 0, 100 );
+my @anonymous_small_donors = @{$year->anonymous_donors_between( 0, 100 )};
 is (@anonymous_small_donors, 1, 'Small anonymous donors', );
 
-my @named_big_donors = $year->named_donors_between( 101, undef );
-is (@named_big_donors, 1, 'Big donors',);
+my @named_big_donors = @{$year->named_donors_between( 101, undef )};
+is (@named_big_donors, 1, 'Big named donors',);
 
 done_testing();

--- a/IFComp/t/colossal_fund.t
+++ b/IFComp/t/colossal_fund.t
@@ -9,13 +9,9 @@ use Path::Class::Dir;
 
 use IFComp::ColossalFund;
 
-my $cf_data_dir = Path::Class::Dir->new(
-    "$FindBin::Bin/colossal"
-);
+my $cf_data_dir = Path::Class::Dir->new( "$FindBin::Bin/colossal" );
 
-my $cf = IFComp::ColossalFund->new( {
-    data_directory => $cf_data_dir,
-} );
+my $cf = IFComp::ColossalFund->new( { data_directory => $cf_data_dir, } );
 
 is( $cf->collected, 4521 );
 is( @{ $cf->years }, 2, 'Current collected amount' );
@@ -25,13 +21,13 @@ is( $cf->maximum_prize, 245, 'Maximum prize' );
 my $year = $cf->years->[0];
 is( @{ $year->donors }, 4, 'Total donors' );
 
-my @named_small_donors = @{$year->named_donors_between( 0, 100 )};
-is (@named_small_donors, 2, 'Small named donors', );
+my @named_small_donors = @{ $year->named_donors_between( 0, 100 ) };
+is( @named_small_donors, 2, 'Small named donors', );
 
-my @anonymous_small_donors = @{$year->anonymous_donors_between( 0, 100 )};
-is (@anonymous_small_donors, 1, 'Small anonymous donors', );
+my @anonymous_small_donors = @{ $year->anonymous_donors_between( 0, 100 ) };
+is( @anonymous_small_donors, 1, 'Small anonymous donors', );
 
-my @named_big_donors = @{$year->named_donors_between( 101, undef )};
-is (@named_big_donors, 1, 'Big named donors',);
+my @named_big_donors = @{ $year->named_donors_between( 101, undef ) };
+is( @named_big_donors, 1, 'Big named donors', );
 
 done_testing();

--- a/IFComp/t/model_ColossalFund.t
+++ b/IFComp/t/model_ColossalFund.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::More;
 
-
 BEGIN { use_ok 'IFComp::Model::ColossalFund' }
 
 done_testing();

--- a/IFComp/t/model_ColossalFund.t
+++ b/IFComp/t/model_ColossalFund.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+
+BEGIN { use_ok 'IFComp::Model::ColossalFund' }
+
+done_testing();


### PR DESCRIPTION
This adds:

• A new action at /about/colossal/[year] that displays a Colossal Fun donor wall for a particular year (defaults to current year), drawing data from a given CSV file

• A new object class (and Catalyst model interface) representing CF donors (current and historical) and facts about the current year's CF drive, drawing data from a given JSON file. This replaces the Template Toolkit datafile currently in use for this purpose.