### PR TITLE
Repairing chained-path config for admin actions.

### DIFF
--- a/IFComp/lib/IFComp/Controller/Admin.pm
+++ b/IFComp/lib/IFComp/Controller/Admin.pm
@@ -20,13 +20,17 @@ A controller for administrative functions
 
 =cut
 
-sub index : Chained('/') : Path : Args(0) {
+sub root : Chained('/') : PathPart( 'admin' ) : CaptureArgs(0) {
     my ( $self, $c ) = @_;
 
     unless ( $c->user && $c->check_any_user_role('votecounter') ) {
         $c->res->redirect('/');
         return;
     }
+}
+
+sub index : Chained( 'root' ) : PathPart('') : Args(0) {
+    my ( $self, $c ) = @_;
 
     $c->stash->{template} = "admin/index.tt";
 }

--- a/IFComp/lib/IFComp/Controller/Admin/Voting.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Voting.pm
@@ -22,22 +22,11 @@ A controller for voting reports.
 
 =cut
 
-sub index : Chained('/admin') : Path : Args(0) {
+sub index : Chained('/admin/root') : PathPart( 'voting') : Args(0) {
     my ( $self, $c ) = @_;
 
     # Must have a votecounter
-    my @user_roles       = $c->user->user_roles;
-    my $votecounter_role = 'votecounter';
-    my $has_votecounter_role =
-        grep { $_->role->name eq $votecounter_role } @user_roles;
-
-    unless ($has_votecounter_role) {
-        $c->log->warn(
-            sprintf(
-                "User %s does not have role %s",
-                $c->user->name, $votecounter_role
-            )
-        );
+    unless ( $c->user && $c->check_any_user_role('votecounter') ) {
         $c->res->redirect('/');
         return;
     }
@@ -135,7 +124,7 @@ sub index : Chained('/admin') : Path : Args(0) {
 }
 
 # /admin/voting/:entry_id
-sub show_entry : Chained("/admin/voting") : Path : Args(1) {
+sub show_entry : Chained('index') : Path : Args(1) {
     my ( $self, $c, $entry_id ) = @_;
 
     my $entry      = $c->model('IFCompDB::Entry');

--- a/IFComp/lib/IFComp/Controller/Admin/Voting/IP.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Voting/IP.pm
@@ -23,7 +23,7 @@ A controller for voting reports.
 
 # /admin/voting/ip/:ip/:comp_id
 # Show the voting from this IP for this entry
-sub show_ip : Chained("/admin/voting") : Path : Args(2) {
+sub show_ip : Chained("/admin/voting/index") : Path : Args(2) {
     my ( $self, $c, $ip, $comp_id ) = @_;
 
     my $comp = $c->model('IFCompDB::Comp')->find($comp_id);

--- a/IFComp/lib/IFComp/Controller/Admin/Voting/User.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Voting/User.pm
@@ -23,7 +23,7 @@ A controller for voting reports.
 
 # /admin/voting/user/:user_id/:comp_id
 # Show how this user voted for this comp
-sub show_user : Chained("/admin/voting") : Path : Args(2) {
+sub show_user : Chained("/admin/voting/index") : Path : Args(2) {
     my ( $self, $c, $user_id, $comp_id ) = @_;
 
     my $comp = $c->model('IFCompDB::Comp')->find($comp_id);

--- a/IFComp/t/admin.t
+++ b/IFComp/t/admin.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+
+unless ( eval q{use Test::WWW::Mechanize::Catalyst 0.55; 1} ) {
+    plan skip_all => 'Test::WWW::Mechanize::Catalyst >= 0.55 required';
+    exit 0;
+}
+
+use FindBin;
+use lib ("$FindBin::Bin/lib");
+use IFCompTest;
+
+my $schema = IFCompTest->init_schema();
+
+ok( my $mech =
+        Test::WWW::Mechanize::Catalyst->new( catalyst_app => 'IFComp' ),
+    'Created mech object'
+);
+
+my $VOTING_TITLE_REGEX = qr/Admin - Voting/;
+
+$mech->get_ok('http://localhost/admin/voting');
+$mech->title_unlike( $VOTING_TITLE_REGEX,
+    'Admin-access attempt without a login got us redirected',
+);
+
+IFCompTest::log_in_as_judge($mech);
+$mech->get_ok('http://localhost/admin/voting');
+$mech->title_unlike( $VOTING_TITLE_REGEX,
+    'Admin-access attempt without an appropriate role got us redirected',
+);
+
+IFCompTest::log_in_as_votecounter($mech);
+$mech->get_ok('http://localhost/admin/voting');
+$mech->title_like( $VOTING_TITLE_REGEX,
+    'Admin-access attempt with an appropriate role worked just fine',
+);
+
+done_testing();

--- a/IFComp/t/lib/IFCompTest.pm
+++ b/IFComp/t/lib/IFCompTest.pm
@@ -80,8 +80,18 @@ sub init_schema {
             ],
             [   2, 'Alice Author', 'f4384fd7e541f4279d003cf89fc40c33',
                 $SALT, 'author@example.com', 1, undef, 1
+            ],
+            [   3,
+                'Victor Votecounter',
+                'f4384fd7e541f4279d003cf89fc40c33',
+                $SALT, 'votecounter@example.com', 1, undef, 1
             ]
         ],
+    );
+
+    $schema->populate( 'Role', [ [ 'id', 'name' ], [ 1, 'votecounter' ] ] );
+
+    $schema->populate( 'UserRole', [ [ 'id', 'user', 'role' ], [ 1, 3, 1, ] ],
     );
 
     # There are two comps - last year and this year. The current comp is open
@@ -144,9 +154,18 @@ sub log_in_as_author {
     _log_in_as( $mech, 'author@example.com', 'Alice Author' );
 }
 
+sub log_in_as_votecounter {
+    my ($mech) = @_;
+    _log_in_as( $mech, 'votecounter@example.com', 'Victor Votecounter' );
+}
+
 sub _log_in_as {
     my ( $mech, $email, $name ) = @_;
 
+    # Quietly clear out any existing login first
+    $mech->get('http://localhost/auth/logout');
+
+    # Now try (with tests!) the requested login
     $mech->get_ok('http://localhost/auth/login');
     $mech->submit_form_ok(
         {   fields => {


### PR DESCRIPTION
Discovered while working on a new admin-only feature that various admin actions weren't correctly chained into the rest of the application. As a result, some pages that should be restricted to admin views are visible to the public (albeit with non-obvious URLs, and half the time resulting in HTTP 500 responses).

This chains them up better, and also simplifies one role-check to use Catalyst standards. There are no changes made to outward-facing paths.