### PR TITLE
Adding admin view of feedback.

### DIFF
--- a/IFComp/lib/IFComp/Controller/Admin.pm
+++ b/IFComp/lib/IFComp/Controller/Admin.pm
@@ -23,7 +23,9 @@ A controller for administrative functions
 sub root : Chained('/') : PathPart( 'admin' ) : CaptureArgs(0) {
     my ( $self, $c ) = @_;
 
-    unless ( $c->user && $c->check_any_user_role('votecounter') ) {
+    unless ( $c->user
+        && $c->check_any_user_role( 'votecounter', 'curator', ) )
+    {
         $c->res->redirect('/');
         return;
     }

--- a/IFComp/lib/IFComp/Controller/Admin/Feedback.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Feedback.pm
@@ -1,0 +1,34 @@
+package IFComp::Controller::Admin::Feedback;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+sub index : Chained('/admin/root') : PathPart( 'feedback') : Args(0) {
+    my ( $self, $c ) = @_;
+
+    unless ( $c->user && $c->check_any_user_role('curator') ) {
+        $c->log->debug("get outta here");
+        $c->res->redirect('/');
+        return;
+    }
+
+    my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
+
+    my $feedback_rs = $c->model('IFCompDB::Feedback')->search(
+        {   comp => $current_comp->id,
+            text => { '!=', undef },
+        },
+        {   join     => [ 'entry', 'judge' ],
+            order_by => [ 'name',  'title' ],
+        }
+    );
+
+    $c->stash->{feedback_rs} = $feedback_rs;
+    $c->stash->{template}    = "admin/feedback/index.tt";
+
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/IFComp/lib/IFComp/Controller/Admin/Feedback.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Feedback.pm
@@ -8,7 +8,6 @@ sub index : Chained('/admin/root') : PathPart( 'feedback') : Args(0) {
     my ( $self, $c ) = @_;
 
     unless ( $c->user && $c->check_any_user_role('curator') ) {
-        $c->log->debug("get outta here");
         $c->res->redirect('/');
         return;
     }

--- a/IFComp/root/src/admin/feedback/index.tt
+++ b/IFComp/root/src/admin/feedback/index.tt
@@ -1,0 +1,22 @@
+<div class="container">
+
+<h1>All feedback</h1>
+
+<p>
+Here is all the feedback received this year, sorted by judge name.</p>
+
+<p><strong>Please consider the contents of this page sensitive information.</strong> Outside of this page, only the author of a given entry can see the feedback left for it, and in that case they cannot see the identity of the judge who wrote it (unless the judge volunteered this information in the text of the feedback itself.)
+</p>
+
+<hr />
+
+[% IF feedback_rs.count %]
+    [% WHILE (feedback = feedback_rs.next) %]
+        <p><strong>[% feedback.judge.name %] ([% feedback.judge.email %])</strong>, on [% feedback.entry.title %]:</p>
+        <blockquote>[% feedback.text | html | html_para %]</blockquote>
+    [% END %]
+[% ELSE %]
+<p>Hmm, actually, there isn't any feedback to display right now.</p>
+[% END %]
+
+</div>

--- a/IFComp/root/src/admin/feedback/index.tt
+++ b/IFComp/root/src/admin/feedback/index.tt
@@ -12,7 +12,7 @@ Here is all the feedback received this year, sorted by judge name.</p>
 
 [% IF feedback_rs.count %]
     [% WHILE (feedback = feedback_rs.next) %]
-        <p><strong>[% feedback.judge.name %] ([% feedback.judge.email %])</strong>, on [% feedback.entry.title %]:</p>
+        <p><strong>[% feedback.judge.name | html %] ([% feedback.judge.email | html %])</strong>, on [% feedback.entry.title | html %]:</p>
         <blockquote>[% feedback.text | html | html_para %]</blockquote>
     [% END %]
 [% ELSE %]

--- a/IFComp/root/src/admin/index.tt
+++ b/IFComp/root/src/admin/index.tt
@@ -7,11 +7,12 @@
      <p>The following functions are available for administrators</p>
 
      <ul>
+        [% IF c.check_user_roles( 'votecounter' ) %]
         <li><a href="[% c.uri_for('/admin/voting/') %]">Voting</a></li>
-     </ul>
-     
-     <ul>
+        [% END %]
+        [% IF c.check_user_roles( 'curator' ) %]
         <li><a href="[% c.uri_for('/admin/feedback/') %]">Feedback</a></li>
+        [% END %]
      </ul>
      
 </div>

--- a/IFComp/root/src/admin/index.tt
+++ b/IFComp/root/src/admin/index.tt
@@ -10,4 +10,8 @@
         <li><a href="[% c.uri_for('/admin/voting/') %]">Voting</a></li>
      </ul>
      
+     <ul>
+        <li><a href="[% c.uri_for('/admin/feedback/') %]">Feedback</a></li>
+     </ul>
+     
 </div>

--- a/IFComp/t/feedback.t
+++ b/IFComp/t/feedback.t
@@ -59,4 +59,11 @@ is( $feedback->text, $FEEDBACK_TEXT, 'Feedback was recorded in the DB.' );
 is( $feedback->entry->id, 100, 'Feedback entry is correct.' );
 is( $feedback->judge->id, 1,   'Feedback judge is correct.' );
 
+# Test the admin view of current feedback.
+IFCompTest::log_in_as_curator($mech);
+
+$mech->get_ok('http://localhost/admin/feedback');
+
+$mech->content_like(qr/$FEEDBACK_TEXT/);
+
 done_testing();

--- a/IFComp/t/lib/IFCompTest.pm
+++ b/IFComp/t/lib/IFCompTest.pm
@@ -85,13 +85,20 @@ sub init_schema {
                 'Victor Votecounter',
                 'f4384fd7e541f4279d003cf89fc40c33',
                 $SALT, 'votecounter@example.com', 1, undef, 1
+            ],
+            [   4,
+                'Connie Curator',
+                'f4384fd7e541f4279d003cf89fc40c33',
+                $SALT, 'curator@example.com', 1, undef, 1
             ]
         ],
     );
 
-    $schema->populate( 'Role', [ [ 'id', 'name' ], [ 1, 'votecounter' ] ] );
+    $schema->populate( 'Role',
+        [ [ 'id', 'name' ], [ 1, 'votecounter' ], [ 2, 'curator' ] ] );
 
-    $schema->populate( 'UserRole', [ [ 'id', 'user', 'role' ], [ 1, 3, 1, ] ],
+    $schema->populate( 'UserRole',
+        [ [ 'id', 'user', 'role' ], [ 1, 3, 1, ], [ 2, 4, 2 ] ],
     );
 
     # There are two comps - last year and this year. The current comp is open
@@ -159,6 +166,11 @@ sub log_in_as_author {
 sub log_in_as_votecounter {
     my ($mech) = @_;
     _log_in_as( $mech, 'votecounter@example.com', 'Victor Votecounter' );
+}
+
+sub log_in_as_curator {
+    my ($mech) = @_;
+    _log_in_as( $mech, 'curator@example.com', 'Connie Curator' );
 }
 
 sub _log_in_as {


### PR DESCRIPTION
New action: /admin/feedback

Displays all collected feedback, ordered by judge.

Locked to the 'curator' role because I didn't feel like introducing a new role for this? May change mind on that later.