### PR TITLE
prevent users from submitting too many entries, fixes #85

### DIFF
--- a/IFComp/lib/IFComp/Controller/About.pm
+++ b/IFComp/lib/IFComp/Controller/About.pm
@@ -108,7 +108,7 @@ sub colossal_fund : Path('colossal') {
     my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
     $year ||= $current_comp->year;
 
-    my $cf = $c->model('ColossalFund');
+    my $cf      = $c->model('ColossalFund');
     my $cf_year = $cf->year($year) || $cf->year( $year - 1 );
 
     unless ($cf_year) {

--- a/IFComp/lib/IFComp/Controller/Admin/Voting/IP.pm
+++ b/IFComp/lib/IFComp/Controller/Admin/Voting/IP.pm
@@ -30,7 +30,7 @@ sub show_ip : Chained("/admin/voting/index") : Path : Args(2) {
     my @entries =
         $c->model('IFCompDB::Entry')->search( { comp => $comp_id } );
     my @entry_ids = map { $_->id } @entries;
-    my @votes = $c->model('IFCompDB::Vote')->search(
+    my @votes     = $c->model('IFCompDB::Vote')->search(
         {   entry => \@entry_ids,
             ip    => $ip,
         }

--- a/IFComp/lib/IFComp/Controller/Entry.pm
+++ b/IFComp/lib/IFComp/Controller/Entry.pm
@@ -92,17 +92,6 @@ sub create : Chained('root') : PathPart('create') : Args(0) {
         $c->res->redirect( $c->uri_for_action('/entry/list') );
     }
 
-    unless (
-        $c->model('IFCompDB::Entry')->search(
-            {   author => $c->user->get_object->id,
-                comp   => $c->stash->{current_comp}->id,
-            }
-        )->count < $MAX_ENTRIES
-        )
-    {
-        $c->res->redirect( $c->uri_for_action('/entry/list') );
-    }
-
     my %new_result_args = (
         comp   => $c->stash->{current_comp},
         author => $c->user->get_object->id,

--- a/IFComp/lib/IFComp/Form/Entry.pm
+++ b/IFComp/lib/IFComp/Form/Entry.pm
@@ -14,6 +14,7 @@ has '+html_prefix' => ( default => 1 );
 use Readonly;
 Readonly my $MAX_FILE_SIZE => 10485760;
 Readonly my $MAX_GAME_SIZE => 78643200;
+Readonly my $MAX_ENTRIES   => 3;
 
 has_field 'title' => (
     required  => 1,
@@ -190,6 +191,20 @@ sub validate_main_upload {
         )
     {
         $field->add_error("You must provide a reason for this update.");
+    }
+}
+
+sub validate {
+    my $self = shift;
+
+    my $entry_count = $self->schema->resultset('Entry')->search(
+        {   author => $self->item->author->id,
+            comp   => $self->item->comp->id,
+        }
+    )->count;
+
+    if ( $entry_count >= $MAX_ENTRIES && !$self->item->id ) {
+        $self->add_form_error("INVALID_ENTRY_COUNT");
     }
 }
 

--- a/IFComp/root/src/entry/update.tt
+++ b/IFComp/root/src/entry/update.tt
@@ -44,10 +44,22 @@
 </div>
 
 [% BLOCK error_div %]
-[% IF form.has_errors || withdrawal_form.has_errors %]
-<div class="alert alert-danger">
-<p>Your form submission had some problems; please see below for more details.</p>
-</div>
-[% END %]
+    [% IF form.has_errors || withdrawal_form.has_errors %]
+        <div class="alert alert-danger">
+            [% too_many = 0 %]
+            [% FOREACH i IN form.errors %]
+                [% IF i == "INVALID_ENTRY_COUNT" %]
+                    [% too_many = 1 %]
+                    <p>You have already reached your maximum number of entries
+                    for this competition. You must withdraw an entry in order
+                    to submit a new one.</p>
+                [% END %]
+            [% END %]
+            [% IF too_many == 0 || form.errors.size > 1 %]
+                <p>[% IF too_many == 0 %]Your[% ELSE %]Additionally, your[% END %]
+                form submission had some problems; please see below for more details.</p>
+            [% END %]
+        </div>
+    [% END %]
 [% END %]
 

--- a/IFComp/t/controller_Play.t
+++ b/IFComp/t/controller_Play.t
@@ -26,7 +26,7 @@ IFCompTest->process_test_entries($schema);
 use DateTime;
 my $past_ymd = DateTime->now->subtract( days => 2 )->ymd;
 my $future_ymd = DateTime->now->add( days => 2 )->ymd;
-my $comp = $schema->resultset('Comp')->find(2);
+my $comp       = $schema->resultset('Comp')->find(2);
 foreach (qw(intents_open intents_close entries_due judging_begins)) {
     $comp->$_($past_ymd);
 }

--- a/IFComp/t/feedback.t
+++ b/IFComp/t/feedback.t
@@ -26,7 +26,7 @@ IFCompTest::log_in_as_judge($mech);
 use DateTime;
 my $past_ymd = DateTime->now->subtract( days => 2 )->ymd;
 my $future_ymd = DateTime->now->add( days => 2 )->ymd;
-my $comp = $schema->resultset('Comp')->find(2);
+my $comp       = $schema->resultset('Comp')->find(2);
 foreach (qw(intents_open intents_close entries_due judging_begins)) {
     $comp->$_($past_ymd);
 }


### PR DESCRIPTION
This uses the add_form_error() method to pass a token back to the form template as there is no specific field to use to inform the author of their mistake. Some minor language processing is done in order to make the error message more natural in the case where more than one mistake has been made.

[also, ran tidyall]