### PR TITLE
Random default

### DIFF
--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -37,6 +37,7 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
     }
 
     my @entries;
+
     # If we have an 'alphabetize' param defined, sort the games by alpha.
     # Otherwise, shuffle them, also seeding off the user's ID if we're in
     # personal-shuffle mode.

--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -52,7 +52,17 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
             $seed = $c->user->get_object->id;
             $c->stash->{is_personalized} = 1;
         }
-        my $order_by = "rand($seed)";
+
+        # Peek into our app config to see if we're running SQLite.
+        # If so, randomize via random(). Otherwise, use rand().
+        my $order_by;
+        my $dsn = $c->config->{'Model::IFCompDB'}->{connect_info}->{dsn};
+        if ( $dsn =~ /SQLite/ ) {
+            $order_by = "random($seed)";
+        }
+        else {
+            $order_by = "rand($seed)";
+        }
         @entries = $current_comp->entries( {}, { order_by => $order_by, } );
     }
     $c->stash->{entries} = \@entries;

--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -37,7 +37,14 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
     }
 
     my @entries;
-    if ( $c->req->params->{shuffle} ) {
+    # If we have an 'alphabetize' param defined, sort the games by alpha.
+    # Otherwise, shuffle them, also seeding off the user's ID if we're in
+    # personal-shuffle mode.
+    if ( $c->req->params->{alphabetize} ) {
+        @entries = sort { $a->sort_title cmp $b->sort_title }
+            $current_comp->entries();
+    }
+    else {
         $c->stash->{is_shuffled} = 1;
         my $seed = '';
         if ( $c->user && $c->req->params->{personalize} ) {
@@ -47,11 +54,6 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
         my $order_by = "rand($seed)";
         @entries = $current_comp->entries( {}, { order_by => $order_by, } );
     }
-    else {
-        @entries = sort { $a->sort_title cmp $b->sort_title }
-            $current_comp->entries();
-    }
-
     $c->stash->{entries} = \@entries;
 
     my $user_is_author = 0;

--- a/IFComp/root/src/ballot/index.tt
+++ b/IFComp/root/src/ballot/index.tt
@@ -56,13 +56,16 @@
         <a href="[% c.uri_for( '/ballot', { shuffle => 1 } ) %]#browse" type="submit" class="btn btn-default btn-lg">
             <span class="glyphicon glyphicon-random"></span> Random Shuffle
         </a>
+        <a href="[% c.uri_for( '/ballot', { shuffle => 1, personalize => 1 } ) %]#browse" type="submit" class="btn btn-primary btn-lg">
+                   <span class="glyphicon glyphicon-user"></span> Personal Shuffle
+        </a>
         <a href="[% c.uri_for( '/ballot', ) %]#browse" type="submit" class="btn btn-default btn-lg">
             <span class="glyphicon glyphicon-list"></span> Alphabetize
         </a>
         </p>
     [% ELSE %]
         <p style="text-align:center;">
-        <a href="javascript:location.reload()" type="submit" class="btn btn-default btn-lg">
+        <a href="javascript:location.reload()" type="submit" class="btn btn-primary btn-lg">
             <span class="glyphicon glyphicon-random"></span> Random Shuffle
         </a>
         [% IF c.user %]
@@ -85,6 +88,9 @@
            <span class="glyphicon glyphicon-user"></span> Personal Shuffle
         </a>
     [% END %]
+    <a href="[% c.uri_for( '/ballot', ) %]#browse" type="submit" class="btn btn-primary btn-lg">
+        <span class="glyphicon glyphicon-list"></span> Alphabetize
+    </a>
     </p>
 [% END %]
 


### PR DESCRIPTION
* Makes random-shuffle the default game sort-order, in /ballot.

* Always make all the sorting buttons available, and shade in the active one.

* Allow random shuffle to work with SQLite. (Needed to add this because the new random-shuffle default appears a lot in test scripts, and the test environment uses SQLite.)
