### PR TITLE
Removing the poorly understood 'es6-shim' hack from 2016

### DIFF
--- a/IFComp/lib/IFComp/Controller/Play.pm
+++ b/IFComp/lib/IFComp/Controller/Play.pm
@@ -68,25 +68,9 @@ sub download : Chained('fetch_entry') : Args(0) {
     if ( $filename =~ /\.html?$/i ) {
         my $body = $entry->main_file->slurp( iomode => '<:encoding(UTF-8)' );
 
-        # XXX Horrible hack to get around a thing in Twine-generated files
-        #     that I don't understand yet.
-        if ( $body =~ /es6-shim/ ) {
-
-            # It's a Twine file that uses a 'es6-shim', whatever that is.
-            # Well, it doesn't play nice with UTF-8, I guess?
-            # Re-slurp without UTF-8 encoding.
-            my $non_utf8 = $entry->main_file->slurp;
-
-            # Replace everything in the body from the first mention of
-            # 'es6-shim' onwards with poorly-encoded version of same.
-            # Else the page will fail to load. No, I don't know either.
-            my ($shim_text) = $non_utf8 =~ /(es6-shim.*)$/s;
-            $body =~ s/es6-shim.*//s;
-            $body .= $shim_text;
-        }
         $c->res->header(
             'Content-Disposition' => qq{attachment; filename="$filename"} );
-        $c->res->content_type('text/html');
+        $c->res->content_type('text/htmll; charset=utf-8');
         $c->res->code(200);
         $c->res->body($body);
     }


### PR DESCRIPTION
This hack was put into place under duress during the 2016 comp, in order to fix certain Twine games that weren't loading... at the cost of removing UTF-8 encoding from them. Per the comments, I didn't know what an "es6-shim" was, and I still don't.

An author noted this year that the downloaded editions of their game had bad encoding (specifically, em-dash characters turned into garbage). The game does contain the "es6-shim" stuff, and the 2016 hack dutifully messed up their game's character encoding.

When I remove this hack, their game loads correctly, and is correctly encoded.

I propose that we declare the problem to have magically fixed itself in the intervening three years, and just revert the hack entirely.