### PR TITLE
Fixes #189

### DIFF
--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -42,7 +42,6 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
     }
     $c->stash->{user_is_author} = $user_is_author;
 
-    $c->log->debug( 'All done with this action.' . localtime );
 }
 
 sub fetch_entries : Chained('root') : PathPart('') : CaptureArgs(0) {
@@ -76,7 +75,6 @@ sub fetch_entries : Chained('root') : PathPart('') : CaptureArgs(0) {
         my $current_comp = $c->stash->{current_comp};
         @entries = $current_comp->entries( {}, { order_by => $order_by, } );
         $c->stash->{entries} = \@entries;
-        $c->log->debug( 'Stashed.' . localtime );
     }
 }
 

--- a/IFComp/lib/IFComp/Controller/Ballot.pm
+++ b/IFComp/lib/IFComp/Controller/Ballot.pm
@@ -36,16 +36,26 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
         return;
     }
 
-    my @entries;
+    my $user_is_author = 0;
+    if ( $c->user && $c->user->get_object->current_comp_entries ) {
+        $user_is_author = 1;
+    }
+    $c->stash->{user_is_author} = $user_is_author;
+
+    $c->log->debug( 'All done with this action.' . localtime );
+}
+
+sub fetch_entries : Chained('root') : PathPart('') : CaptureArgs(0) {
+    my ( $self, $c ) = @_;
 
     # If we have an 'alphabetize' param defined, sort the games by alpha.
     # Otherwise, shuffle them, also seeding off the user's ID if we're in
     # personal-shuffle mode.
     if ( $c->req->params->{alphabetize} ) {
-        @entries = sort { $a->sort_title cmp $b->sort_title }
-            $current_comp->entries();
+        $c->forward('fetch_alphabetized_entries');
     }
     else {
+        my @entries;
         $c->stash->{is_shuffled} = 1;
         my $seed = '';
         if ( $c->user && $c->req->params->{personalize} ) {
@@ -63,24 +73,34 @@ sub root : Chained('/') : PathPart('ballot') : CaptureArgs(0) {
         else {
             $order_by = "rand($seed)";
         }
+        my $current_comp = $c->stash->{current_comp};
         @entries = $current_comp->entries( {}, { order_by => $order_by, } );
+        $c->stash->{entries} = \@entries;
+        $c->log->debug( 'Stashed.' . localtime );
     }
-    $c->stash->{entries} = \@entries;
-
-    my $user_is_author = 0;
-    if ( $c->user && $c->user->get_object->current_comp_entries ) {
-        $user_is_author = 1;
-    }
-    $c->stash->{user_is_author} = $user_is_author;
 }
 
-sub index : Chained('root') : PathPart('') : Args(0) {
+sub fetch_alphabetized_entries : Chained('root') : PathPart('') :
+    CaptureArgs(0) {
+    my ( $self, $c ) = @_;
+
+    my @entries;
+
+    my $current_comp = $c->stash->{current_comp};
+
+    @entries =
+        sort { $a->sort_title cmp $b->sort_title } $current_comp->entries();
+    $c->stash->{entries} = \@entries;
+
+}
+
+sub index : Chained('fetch_entries') : PathPart('') : Args(0) {
     my ( $self, $c ) = @_;
 
     $c->stash->{zip_file_mb} = $c->config->{zip_file_mb};
 }
 
-sub vote : Chained('root') : PathPart('vote') : Args(0) {
+sub vote : Chained('fetch_alphabetized_entries') : PathPart('vote') : Args(0) {
     my ( $self, $c ) = @_;
 
     if ( $c->stash->{current_comp}->status ne 'open_for_judging' ) {


### PR DESCRIPTION
/ballot and /ballot/vote now pull from different root actions. The latter always alphabetizes the stashed entries; the former does it only if there's a parameter asking for it, and shuffles them otherwise.