### PR TITLE
Add paypal address to user accounts

### DIFF
--- a/IFComp/lib/IFComp/Controller/User.pm
+++ b/IFComp/lib/IFComp/Controller/User.pm
@@ -42,6 +42,7 @@ sub register : Path('register') : Args(0) {
                 forum_handle    => $form->field('forum_handle')->value,
                 url             => $form->field('url')->value,
                 email_is_public => $form->field('email_is_public')->value,
+                paypal          => $form->field('paypal')->value,
             }
         );
 

--- a/IFComp/lib/IFComp/Form/UserFields.pm
+++ b/IFComp/lib/IFComp/Form/UserFields.pm
@@ -6,8 +6,9 @@ with 'IFComp::Form::PasswordFields';
 use Regexp::Common qw( URI );
 
 has_field 'email' => (
-    type     => 'Email',
-    required => 1,
+    type      => 'Email',
+    required  => 1,
+    maxlength => 64,
 );
 
 has_field 'email_is_public' => (
@@ -37,8 +38,9 @@ has_field 'forum_handle' => (
 );
 
 has_field 'paypal' => (
-    type  => 'Email',
-    label => 'Paypal address',
+    type      => 'Email',
+    label     => 'Paypal address',
+    maxlength => 64,
 );
 
 has_field 'submit' => (

--- a/IFComp/lib/IFComp/Form/UserFields.pm
+++ b/IFComp/lib/IFComp/Form/UserFields.pm
@@ -36,6 +36,11 @@ has_field 'forum_handle' => (
     label => 'Intfiction.org forum handle',
 );
 
+has_field 'paypal' => (
+    type  => 'Email',
+    label => 'Paypal address',
+);
+
 has_field 'submit' => (
     type         => 'Submit',
     value        => 'Register',

--- a/IFComp/lib/IFComp/Schema/Result/User.pm
+++ b/IFComp/lib/IFComp/Schema/Result/User.pm
@@ -46,6 +46,8 @@ __PACKAGE__->table("user");
   is_nullable: 0
   size: 128
 
+User's real name
+
 =head2 password
 
   data_type: 'char'
@@ -64,6 +66,8 @@ __PACKAGE__->table("user");
   default_value: (empty string)
   is_nullable: 0
   size: 64
+
+Email doubles as login ID
 
 =head2 email_is_public
 
@@ -118,6 +122,14 @@ __PACKAGE__->table("user");
   is_nullable: 1
   size: 32
 
+=head2 paypal
+
+  data_type: 'char'
+  is_nullable: 1
+  size: 64
+
+User's PayPal account name (usually an email address)
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -162,6 +174,8 @@ __PACKAGE__->add_columns(
   { data_type => "char", is_nullable => 1, size => 36 },
   "forum_handle",
   { data_type => "char", is_nullable => 1, size => 32 },
+  "paypal",
+  { data_type => "char", is_nullable => 1, size => 64 },
 );
 
 =head1 PRIMARY KEY
@@ -270,8 +284,8 @@ __PACKAGE__->has_many(
 
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07045 @ 2017-09-17 13:13:17
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0GAZNFGyrHszTo/6wUZPKg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-06-02 13:17:47
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OHcMlyDlSbgVqzFqGczQRg
 
 __PACKAGE__->add_column(
     '+password' => {

--- a/IFComp/root/src/user/register.tt
+++ b/IFComp/root/src/user/register.tt
@@ -24,6 +24,11 @@
 <p>Specify your username on the intfiction.org forum to gain access to the authors-only forum during the judging period. (We won't display your forum handle on this site.)</p>
 
 [% form.field( 'forum_handle' ).render %]
+
+<p>Provide the email address of your PayPal account (and not a PayPal.me URL) to help us send you any <a href="https://ifcomp.org/about/prizes" target="_prizes">prize money</a> that your entries might earn. (We will not share this address with anyone, except as needed for this specific purpose.)</p>
+
+[% form.field( 'paypal' ).render %]
+
 </div>
 </div>
 


### PR DESCRIPTION
Prerequisite SQL to run:

```
alter table user add column paypal char(64);
```

This work adds schema support for the above new column, and adds it to user CRUD forms.

DIdn't add any further tests because it rather doesn't seem worthwhile in this case? It's just another optional user form field like many others.