### PR TITLE
Expose entry IDs to their authors, on the entry-management screen.

### DIFF
--- a/IFComp/root/src/entry/list.tt
+++ b/IFComp/root/src/entry/list.tt
@@ -45,9 +45,9 @@
         && ( current_comp.status != 'closed_to_entries' )
        )
     %]
-        <a href="[% c.uri_for_action( '/entry/update', [ entry.id ] ) %]">[% entry.title %]</a> &mdash;
+        <a href="[% c.uri_for_action( '/entry/update', [ entry.id ] ) %]">[% entry.title %]</a> <em>(entry ID: [% entry.id %])</em> &mdash;
     [% ELSE %]
-        <em>[% entry.title %]</em> &mdash;
+        [% entry.title %] <em>(entry ID: [% entry.id %])</em> &mdash;
     [% END %]
     [% IF entry.main_file %]
         Entry complete


### PR DESCRIPTION
Simple change to let authors see their own entries' DB IDs.

This is mainly to help them ask comp organizers about game-specific questions.