### PR TITLE
Simplify transcription setup

### DIFF
--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1003,11 +1003,10 @@ sub update_content_directory {
         # platform type and play file
         $self->clear_play_file;
     }
-    elsif ( $self->platform eq 'parchment' ) {
-        $self->_enable_recording('parchment_options');
-    }
-    elsif ( $self->platform eq 'quixe' ) {
-        $self->_enable_recording('game_options');
+    elsif (( $self->platform eq 'parchment' )
+        || ( $self->platform eq 'quixe' ) )
+    {
+        $self->_enable_recording;
     }
 }
 
@@ -1182,7 +1181,7 @@ EOF
 }
 
 sub _enable_recording {
-    my ( $self, $options_js_object ) = @_;
+    my ($self) = @_;
 
     my $play_file = $self->content_directory->file('play.html');
 
@@ -1196,6 +1195,17 @@ sub _enable_recording {
     }
 
     my $play_html = $play_file->slurp;
+
+    my $options_js_object;
+    if ( $play_html =~ m{game_options.*</head>}s ) {
+
+        # It's Quixe
+        $options_js_object = 'game_options';
+    }
+    else {
+        # It's Parchment
+        $options_js_object = 'parchment_options';
+    }
 
     # Activate transcription, aiming it at the local transcription action.
     # (Via injecting additional values into the game_options config object.)

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1003,12 +1003,7 @@ sub update_content_directory {
         # platform type and play file
         $self->clear_play_file;
     }
-    elsif ( $self->platform eq 'parchment' ) {
-        $self->_mangle_parchment_head;
-    }
     elsif ( $self->platform eq 'quixe' ) {
-        $self->_make_js_file( $self->inform_game_file,
-            $self->inform_game_js_file );
         $self->_mangle_quixe_head;
     }
 }
@@ -1183,54 +1178,6 @@ EOF
 
 }
 
-sub _mangle_parchment_head {
-    my $self = shift;
-
-    my $title    = $self->title;
-    my $entry_id = $self->id;
-
-    my $game_file = $self->inform_game_file->basename;
-
-    my $play_file = $self->content_directory->file('play.html');
-
-    unless ( ( -e $play_file ) && $game_file ) {
-
-        # No play.html? OK, this isn't a standard I7 "with interpreter" arrangement,
-        # so we won't do anything.
-        return;
-    }
-
-    my $play_html = $play_file->slurp;
-
-    # Discard all invocations of interpreter/.
-    $play_html =~ s{<script src="interpreter/.*?</script>}{}g;
-    $play_html =~ s{<link.*?href="interpreter/.*?>}{}g;
-
-    # Add new head tags.
-    my $tag_text  = $self->interpreter_tag_text;
-    my $head_html = <<EOF;
-$tag_text
-<script>
-parchment_options = {
-default_story: [ "$game_file" ],
-lib_path: '/static/interpreter/parchment/',
-lock_story: 1,
-page_title: 0
-};
-
-ifRecorder.saveUrl = "/play/$entry_id/transcribe";
-ifRecorder.story.name = "$title";
-ifRecorder.story.version = "1";
-</script>
-
-EOF
-
-    $play_html =~ s{</head>}{$head_html\n</head>};
-
-    $play_file->spew($play_html);
-
-}
-
 sub _mangle_quixe_head {
     my $self = shift;
 
@@ -1246,17 +1193,6 @@ sub _mangle_quixe_head {
     }
 
     my $play_html = $play_file->slurp;
-
-    # Re-aim interpreter links to our own Quixe interpreter.
-    # (Via re-writing <script src="..." /> invocations.)
-    $play_html =~ s{"interpreter/jquery-.*?min.js"}
-            {"/static/interpreter/glkote/jquery-3.4.1.min.js"};
-    $play_html =~ s{"interpreter/glkote.min.js"}
-            {"/static/interpreter/glkote/glkote.min.js"};
-    $play_html =~ s{"interpreter/quixe.min.js"}
-            {"/static/interpreter/quixe/quixe.min.js"};
-    $play_html =~ s{"interpreter/glkote.css"}
-            {"/static/interpreter/glkote/i7-glkote.css"};
 
     # Activate transcription, aiming it at the local transcription action.
     # (Via injecting additional values into the game_options config object.)

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1003,8 +1003,11 @@ sub update_content_directory {
         # platform type and play file
         $self->clear_play_file;
     }
+    elsif ( $self->platform eq 'parchment' ) {
+        $self->_enable_recording('parchment_options');
+    }
     elsif ( $self->platform eq 'quixe' ) {
-        $self->_enable_quixe_recording;
+        $self->_enable_recording('game_options');
     }
 }
 
@@ -1178,8 +1181,8 @@ EOF
 
 }
 
-sub _enable_quixe_recording {
-    my $self = shift;
+sub _enable_recording {
+    my ( $self, $options_js_object ) = @_;
 
     my $play_file = $self->content_directory->file('play.html');
 
@@ -1196,12 +1199,15 @@ sub _enable_quixe_recording {
 
     # Activate transcription, aiming it at the local transcription action.
     # (Via injecting additional values into the game_options config object.)
-    my $entry_id = $self->id;
-    my $transcription_options =
-          "recording_url: '/play/$entry_id/transcribe',\n"
-        . "recording_format: 'simple',\n";
-    $play_html =~ s[(game_options\s*=\s*{\s*)]
-            [$1$transcription_options]s;
+    my $entry_id           = $self->id;
+    my $transcription_code = <<EOF;
+<script>
+$options_js_object.recording_url = '/play/$entry_id/transcribe'
+$options_js_object.recording_format = 'simple'
+</script>
+EOF
+
+    $play_html =~ s{</head>}{$transcription_code</head>};
 
     $play_file->spew($play_html);
 

--- a/IFComp/lib/IFComp/Schema/Result/Entry.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Entry.pm
@@ -1004,7 +1004,7 @@ sub update_content_directory {
         $self->clear_play_file;
     }
     elsif ( $self->platform eq 'quixe' ) {
-        $self->_mangle_quixe_head;
+        $self->_enable_quixe_recording;
     }
 }
 
@@ -1178,7 +1178,7 @@ EOF
 
 }
 
-sub _mangle_quixe_head {
+sub _enable_quixe_recording {
     my $self = shift;
 
     my $play_file = $self->content_directory->file('play.html');

--- a/IFComp/t/entry_processing.t
+++ b/IFComp/t/entry_processing.t
@@ -62,7 +62,9 @@ is( $schema->resultset('Entry')->find(101)->play_file,
 );
 
 note('Testing Quixe upload...');
-
+ok( file_contains( 102, 'play.html', qr{game_options\.recording_url} ),
+    'Configures the transcription service.',
+);
 is( $schema->resultset('Entry')->find(102)->platform,
     'quixe', 'Platform is correct.',
 );
@@ -90,6 +92,10 @@ ok( $schema->resultset('Entry')->find(112)->has_extra_content,
     'Reports having extra content.' );
 
 note('Testing Parchment...');
+
+ok( file_contains( 103, 'play.html', qr{parchment_options\.recording_url} ),
+    'Configures the transcription service.',
+);
 
 is( $schema->resultset('Entry')->find(103)->platform,
     'parchment', 'Platform is correct.',

--- a/IFComp/t/entry_processing.t
+++ b/IFComp/t/entry_processing.t
@@ -62,9 +62,7 @@ is( $schema->resultset('Entry')->find(101)->play_file,
 );
 
 note('Testing Quixe upload...');
-ok( file_contains( 102, 'play.html', qr{/static/interpreter/quixe/} ),
-    'Links to local interpreter.',
-);
+
 is( $schema->resultset('Entry')->find(102)->platform,
     'quixe', 'Platform is correct.',
 );
@@ -78,9 +76,7 @@ ok( not( $schema->resultset('Entry')->find(102)->has_extra_content ),
     'Does not report having any extra content.' );
 
 note('Testing Quixe upload (with extra content...');
-ok( file_contains( 112, 'play.html', qr{/static/interpreter/quixe/} ),
-    'Links to local interpreter.',
-);
+
 is( $schema->resultset('Entry')->find(112)->platform,
     'quixe', 'Platform is correct.',
 );
@@ -94,17 +90,11 @@ ok( $schema->resultset('Entry')->find(112)->has_extra_content,
     'Reports having extra content.' );
 
 note('Testing Parchment...');
-ok( file_contains( 103, 'play.html', qr{/static/interpreter/parchment/} ),
-    'Links to local interpreter.',
-);
+
 is( $schema->resultset('Entry')->find(103)->platform,
     'parchment', 'Platform is correct.',
 );
-ok( file_contains(
-        103, 'play.html', qr{/static/interpreter/transcript_recorder/}
-    ),
-    'Links to local transcript recorder.',
-);
+
 is( $schema->resultset('Entry')->find(103)->play_file,
     'index.html', 'Play-file set correctly.',
 );


### PR DESCRIPTION
This work reduces the changes that the app makes to its online-play copies of entries' Quixe and Parchment-based websites.

In sum, we dramatically simplify the processing done on these games, allowing them to use the technology they were uploaded with instead of forcing them to use ifcomp.org-hosted copies of software. The earlier "mangling" was necessary in 2014-2015 to enact features regarding transcription and work around Inform bugs, but they haven't been necessary in a long time, and have begun to get in the way of newer work.

* It no longer redirects them to use locally hosted interpreters. Instead, entries use their own, uploaded interpreters.

* It no longer has them use the locally hosted copy of if-recorder.js. Instead, it adds a small <script> block that configures the Quixe or Parchment's on-board transcription technology. (This is not present in older versions of Parchment, which will treat this configuration code as a harmless no-op.)

* Quixe games no longer have their full-javascript-encapsulated versions re-created and replaced.

* Removes transcription support from games using older Parchment technology.

Fixes #244.