### PR TITLE
Update schema to match production db.

### DIFF
--- a/IFComp/lib/IFComp/Schema/Result/Comp.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Comp.pm
@@ -85,7 +85,6 @@ __PACKAGE__->table("comp");
 =head2 organizer
 
   data_type: 'char'
-  default_value: (empty string)
   is_nullable: 0
   size: 64
 
@@ -138,7 +137,7 @@ __PACKAGE__->add_columns(
     is_nullable => 1,
   },
   "organizer",
-  { data_type => "char", default_value => "", is_nullable => 0, size => 64 },
+  { data_type => "char", is_nullable => 0, size => 64 },
 );
 
 =head1 PRIMARY KEY
@@ -201,8 +200,8 @@ __PACKAGE__->has_many(
 
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-07-05 11:06:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:FSIQivDIPdUQpicNmtCw2Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-26 01:36:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:h6mBFZDliFO37V+/lUkCOQ
 
 use DateTime::Moonpig;
 use Moose::Util::TypeConstraints;

--- a/IFComp/lib/IFComp/Schema/Result/Role.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Role.pm
@@ -42,9 +42,8 @@ __PACKAGE__->table("role");
 =head2 name
 
   data_type: 'char'
-  default_value: (empty string)
-  is_nullable: 0
-  size: 8
+  is_nullable: 1
+  size: 16
 
 =cut
 
@@ -57,7 +56,7 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
   },
   "name",
-  { data_type => "char", default_value => "", is_nullable => 0, size => 8 },
+  { data_type => "char", is_nullable => 1, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -91,8 +90,8 @@ __PACKAGE__->has_many(
 
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-07-05 11:06:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MioYhalzINLNppRA32+v2Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-26 01:33:05
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:O3vRC5cNavf4f7iyG6o3OA
 # These lines were loaded from '/home/jjohn/perl5/perlbrew/perls/perl-5.18.2/lib/site_perl/5.18.2/IFComp/Schema/Result/Role.pm' found in @INC.
 # They are now part of the custom portion of this file
 # for you to hand-edit.  If you do not either delete

--- a/IFComp/lib/IFComp/Schema/Result/User.pm
+++ b/IFComp/lib/IFComp/Schema/Result/User.pm
@@ -128,8 +128,6 @@ Email doubles as login ID
   is_nullable: 1
   size: 64
 
-User's PayPal account name (usually an email address)
-
 =cut
 
 __PACKAGE__->add_columns(
@@ -284,8 +282,8 @@ __PACKAGE__->has_many(
 
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-06-02 13:17:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OHcMlyDlSbgVqzFqGczQRg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-26 01:36:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ULwcJUdKVjLtghT8jrK7Mg
 
 __PACKAGE__->add_column(
     '+password' => {

--- a/IFComp/lib/IFComp/Schema/Result/Vote.pm
+++ b/IFComp/lib/IFComp/Schema/Result/Vote.pm
@@ -58,18 +58,17 @@ __PACKAGE__->table("vote");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 ip
+
+  data_type: 'char'
+  is_nullable: 1
+  size: 16
+
 =head2 time
 
   data_type: 'datetime'
   datetime_undef_if_invalid: 1
   is_nullable: 1
-
-=head2 ip
-
-  data_type: 'char'
-  default_value: (empty string)
-  is_nullable: 0
-  size: 15
 
 =cut
 
@@ -97,14 +96,14 @@ __PACKAGE__->add_columns(
     is_foreign_key => 1,
     is_nullable => 0,
   },
+  "ip",
+  { data_type => "char", is_nullable => 1, size => 16 },
   "time",
   {
     data_type => "datetime",
     datetime_undef_if_invalid => 1,
     is_nullable => 1,
   },
-  "ip",
-  { data_type => "char", default_value => "", is_nullable => 0, size => 15 },
 );
 
 =head1 PRIMARY KEY
@@ -118,22 +117,6 @@ __PACKAGE__->add_columns(
 =cut
 
 __PACKAGE__->set_primary_key("id");
-
-=head1 UNIQUE CONSTRAINTS
-
-=head2 C<user>
-
-=over 4
-
-=item * L</user>
-
-=item * L</entry>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint("user", ["user", "entry"]);
 
 =head1 RELATIONS
 
@@ -169,8 +152,8 @@ __PACKAGE__->belongs_to(
 
 #>>>
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-07-05 11:06:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RVvPb6r6iuBRONnsSlb8gg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-05-26 01:36:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MH+dXiE0xxCAOgDuoSod5w
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
While performing work on a different issue, I realized that the schema doesn't match the actual database. In particular, `role.name` is defined in the schema with a size of 8, but the actual data going into it is sometimes larger (_votecounter_).
Sure enough, it has a size of 16 in the db itself.

I downloaded a fresh copy of the database from sword and ran `ifcomp_dump_schema.pl`, and this PR is the result.