### PR TITLE
Update filter code to handle multi-platform descriptions

### DIFF
--- a/IFComp/root/src/_filter_entries.tt
+++ b/IFComp/root/src/_filter_entries.tt
@@ -32,7 +32,13 @@ function updateDisplay() {
     }
     if (filter_platform.length !== 0) {
         $('[id ^= "entry-"').filter(":visible").each(function() {
-            if (!filter_platform.includes($(this).attr('ifcomp-platform'))) {
+            var found = false;
+            filter_platform.forEach(entry => {
+                entry.split(",").forEach(p => {
+                    if (p.includes($(this).attr('ifcomp-platform'))) { found = true; }
+                })
+            });
+            if (!found) {
                 $(this).hide();
                 count -= 1;
             }

--- a/IFComp/root/src/ballot/index.tt
+++ b/IFComp/root/src/ballot/index.tt
@@ -133,19 +133,20 @@
     <p><u>Platform</u></p>
     <select multiple size=8 class="platform-select">
     <option value="platform-all">All</option>
-    <option value="adrift">Adrift</option>
-    <option value="inform">Inform</option>
+    <option value="adrift,adrift-online">Adrift</option>
+    <option value="inform,inform-website">Inform</option>
     <option value="parchment">Parchment</option>
     <option value="quixe">Quixe</option>
-    <option value="tads">TADS</option>
-    <option value="quest">Quest</option>
+    <option value="tads,tads-web-ui">TADS</option>
+    <option value="quest,quest-online">Quest</option>
     <option value="alan">Alan</option>
     <option value="hugo">Hugo</option>
     <option value="windows">Windows</option>
     <option value="website">Website</option>
     <option value="adventuron">Adventuron</option>
     <option value="choicescript">ChoiceScript</option>
-    <option value="ink">Texture</option>
+    <option value="ink">Ink</option>
+    <option value="texture">Texture</option>
     <option value="twine">Twine</option>
     <option value="unity">Unity</option>
     <option value="other">Other</option>


### PR DESCRIPTION
Some platforms have multiple enum values depending on whether they can be played in a browser or not. This fix enhances the filters to support that