### PR TITLE
Make Parchment and Quixe games show up when Inform is selected

### DIFF
--- a/IFComp/root/src/ballot/index.tt
+++ b/IFComp/root/src/ballot/index.tt
@@ -191,7 +191,7 @@
         <option value="adrift,adrift-online">Adrift</option>
     [% END %]
     [% IF platform.inform > 0 %]
-        <option value="inform,inform-website">Inform</option>
+        <option value="inform,inform-website,parchment,quixe">Inform</option>
     [% END %]
     [% IF platform.tads > 0 %]
         <option value="tads,tads-web-ui">TADS</option>


### PR DESCRIPTION
I haven't tested this change locally, because AFAIK it's not possible to test the the ballot locally with real games.

Therefore, this PR is just a guess. But it seems pretty plausible!