### PR TITLE
Fix anchor for "Rising Star Award" section

### DIFF
--- a/IFComp/root/src/about/comp.tt
+++ b/IFComp/root/src/about/comp.tt
@@ -54,7 +54,7 @@ winners of the Miss Congeniality Awards, an honor permanently recorded in <a
 href="[% c.uri_for_action( '/comp/last_comp' ) %]">that year&#8217;s results
 listing</a>.</p>
 
-<h2 id="banana">Rising Star Award</h2>
+<h2 id="risingstar">Rising Star Award</h2>
 
 <p>
 Since the 2021 competition, the IFComp has recognized the highest-rated game by


### PR DESCRIPTION
On the ["about" page](https://ifcomp.org/about/comp), the "Rising Star Award" and "Golden Banana of Discord" headings both use the same anchor `banana`. This PR gives them distinct anchors.

(I haven't set up a dev environment to test this, but how badly can I have got it wrong?)

-----

(off-topic noodling follows; I don't intend for this to derail this trivial PR, can re-raise as an Issue if there's interest in discussing:)

I noticed this in passing when wondering what it would take to properly commemorate Rising Star Award recipients on ifcomp.org.
Up until now, I think they've only been recorded in the ceremony video recordings. (I just created [an IFWiki page](https://www.ifwiki.org/Rising_Star_Award) and added a division to the [2021](https://ifdb.org/viewcomp?id=rniofn8a8pnivk86)/[2022](https://ifdb.org/viewcomp?id=b8iboj34igtpsxoe) comp entries on IFDB, to redress the balance a bit.)

I suppose the fully-automated luxury first-class version which calculates the answer would involve a 'first comp entered' column in User referring to Comp, or similar, plus an ongoing procedural headache for the organisers to populate it. (So, beyond the scope of a unilateral PR.)
You could have a first go at populating it automatically (by looking at users with (non-withdrawn) entries in past years -- for award purposes, it doesn't matter if the 'first comp entered' we record is too recent -- but there'd need to be a way for organisers to override for authors who last entered before records began, authors who aren't re-using their old IFComp account for some reason, etc etc. (I guess currently the organiser does this once rankings are known, researching authors from 1st until they find one who there's no evidence they entered before; would need some way to poke the result of this research into the DB.)

Or, a less fancy version would be for the organisers to continue to determine the recipient by whatever method's been used hitherto, and just provide a script to poke the answer into a new column in Entry created for this purpose in the database, for the historic-results page to display.