### PR TITLE
update actions to node20 and clean up readme

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up perl dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: perllib
         with:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ IFComp
 
 _The software behind the Interactive Fiction Competition._
 
-[![Build Status](https://api.travis-ci.org/iftechfoundation/ifcomp.svg?branch=master)](https://travis-ci.org/iftechfoundation/ifcomp)
-
 This is the software that runs [the Interactive Fiction Competition](http://ifcomp.org), a.k.a. the IFComp, an annual celebration of independently authored, text-based video games that [began in 1995](http://www.ifcomp.org/history/).
 
 The organization of the IFComp changed hands after its 2013 iteration, and the new organizer elected to come at the role with, among other things, a wholly refreshed, public-facing web application. The software found in this repository resulted. We created its first draft over the course of the 2014 IFComp, and it has served the competition annually since then.


### PR DESCRIPTION
We were getting warnings in the github actions results saying that the v2 versions of checkout & cache were on older versions of node and were being deprecated. This brings us up to date.

I also took the opportunity to remove the old link to the TravisCI results from the readme