### PR TITLE
Make app dockerfile work on Windows

### DIFF
--- a/IFComp-Dev/docker-app/Dockerfile
+++ b/IFComp-Dev/docker-app/Dockerfile
@@ -17,4 +17,4 @@ RUN curl -L http://cpanmin.us | perl - App::cpanminus \
 WORKDIR /opt/IFComp
 ENV CATALYST_CONFIG_LOCAL_SUFFIX=dev
 EXPOSE 3000
-CMD ["/opt/IFComp-Dev/script/docker_start.sh"]
+CMD ["bash", "/opt/IFComp-Dev/script/docker_start.sh"]


### PR DESCRIPTION
Docker can't directly run `docker_start.sh` from a mounted Windows directory because Windows lacks executable file permissions. This fixes that issue, which caused the app to crash on startup.