### PR TITLE
Fix warnings in entry registration form

### DIFF
--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -301,12 +301,12 @@ function update_playtime_warning() {
     }
 }
 
-$( '#unreleased').change( function() {
+$( '#game\\.entry\\.unreleased' ).change( function() {
     update_unreleased_warning()
 } );
 
 function update_unreleased_warning() {
-    if ( $( '#unreleased').val() == 0 ) {
+    if ( $( '#game\\.entry\\.unreleased' ).val() == 0 ) {
         $( '#released-game-warning' ).show();        
         $(':input[type="submit"]').prop('disabled', true);
     }

--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -278,6 +278,8 @@ Delete walkthrough file
 [% file.basename %] ( [% stat.size | comma %] bytes; last modifed [% date.ymd %] [% date.hms %] (US/Eastern) )
 [% END %]
 
+[% INCLUDE scripts %]
+
 [% BLOCK scripts %]
 <script>
 var warning_div = $( '#long-game-warning' );


### PR DESCRIPTION
Fixes #397, which broke the script that shows warnings during entry registration. The script now has its intended effect, namely:
- If an author selects the option "_Yes, this entry has already had a prior public release, or I plan on a public release between now and the start of IFComp judging_", they'll see a warning about the comp rules, and the Submit button will be disabled.
- If an author lists their entry's playtime as "_longer than two hours_", they'll see a warning about the judging time limit.