### PR TITLE
Document + partially fix missing CSS rules

### DIFF
--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -96,6 +96,14 @@ option:checked {
   border-color: #66afe9;
 }
 
+[data-theme="dark"] .panel {
+  background-color: #111;
+}
+
+[data-theme="dark"] .panel-default {
+  border-color: #444;\
+}
+
 [data-theme="dark"] .panel-heading {
     background-color: #333;
     color: #eee;
@@ -104,6 +112,7 @@ option:checked {
 [data-theme="dark"] .panel-body {
     background-color: #222;
     color: #eee;
+	border-color: #444;
 }
 
 [data-theme="dark"] .mode-toggle-link {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -78,7 +78,12 @@ a.donate-link:hover {
 
 [data-theme="dark"] .form-control {
     background-color: #222;
+	border-color: #555;
     color: #eee;
+}
+
+[data-theme="dark"] .form-control:focus {
+  border-color: #66afe9;
 }
 
 [data-theme="dark"] .panel-heading {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -98,6 +98,7 @@ a.donate-link:hover {
 
 [data-theme="dark"] .alert-info {
     background-color: #114;
+	border-color: #271c6e;
     color: #eee;
 }
 

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -105,6 +105,10 @@ a.donate-link:hover {
     color: #8bf;
 }
 
+[data-theme="dark"] .alert-info a:hover {
+    color: #b3d4ff;
+}
+
 [data-theme="dark"] .alert-warning {
     background-color: #333;
     color: #db8;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -164,6 +164,10 @@ a.donate-link:hover {
     background-color: #444;
 }
 
+[data-theme="dark"] .dropdown-menu .divider {
+  background-color: #404040;
+}
+
 [data-theme="dark"] img.author-link {
     filter: invert(1);
 }

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -31,7 +31,7 @@ img.author-link {
     vertical-align: top;
 }
 
-// Override Bootstrap
+/* Override Bootstrap */
 code {
     background: none;
     color: black;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -227,3 +227,6 @@ a.donate-link:hover {
     background-color: #333;
 }
 
+[data-theme="dark"] code {
+    color: white;
+}

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -296,7 +296,7 @@ option:checked {
 [data-theme="dark"] .well {
     color: #ddd;
     background-color: #444;
-	/* border-color: MISSING; */
+	border-color: #565656;
 }
 
 [data-theme="dark"] option {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -261,3 +261,7 @@ a.donate-link:hover {
 	color: inherit;
 }
 
+[data-theme="dark"] .page-header {
+	border-bottom-color: #3d3d3d;
+}
+

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -177,19 +177,19 @@ option:checked {
 
 [data-theme="dark"] .btn-primary {
     background-color: #225;
-	/* border-color: MISSING; */
+	border-color: #2e2e7f;
     color: #8bf;
 }
 
 [data-theme="dark"] .btn-primary:hover, [data-theme="dark"] .btn-primary:active {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
-	/* color: MISSING; */
+	background-color: #2d2d7c;
+	border-color: #363696;
 }
 
 [data-theme="dark"] .btn-primary:active:hover {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
+	background-color: #363696;
+	border-color: #44b;
+	color: #b3d4ff;
 }
 
 [data-theme="dark"] .btn-success {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -137,12 +137,30 @@ option:checked {
 
 [data-theme="dark"] .pager li>a {
     background-color: #222;
+	border-color: #444;
     color: #8bf;
+}
+
+[data-theme="dark"] .pager li>a:hover {
+	background-color: #333;
+	color: #b3d4ff;
 }
 
 [data-theme="dark"] .btn-default {
     background-color: #222;
+	border-color: #555;
     color: #8bf;
+}
+
+[data-theme="dark"] .btn-default:hover, .btn-default:active {
+	background-color: #3d3d3d;
+	border-color: #696969;
+	color: #acd0f6;
+}
+
+[data-theme="dark"] .btn-default:active:hover {
+	background-color: #4f4f4f;
+	border-color: #7b7b7b;
 }
 
 [data-theme="dark"] .btn-primary {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -152,7 +152,7 @@ option:checked {
     color: #8bf;
 }
 
-[data-theme="dark"] .btn-default:hover, .btn-default:active {
+[data-theme="dark"] .btn-default:hover, [data-theme="dark"] .btn-default:active {
 	background-color: #3d3d3d;
 	border-color: #696969;
 	color: #acd0f6;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -131,6 +131,18 @@ option:checked {
     border-color: #555;
 }
 
+[data-theme="dark"] .alert-success {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+	/* color: MISSING; */
+}
+
+[data-theme="dark"] .alert-danger {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+	/* color: MISSING; */
+}
+
 [data-theme="dark"] .label {
     color: #222;
 }
@@ -165,7 +177,36 @@ option:checked {
 
 [data-theme="dark"] .btn-primary {
     background-color: #225;
+	/* border-color: MISSING; */
     color: #8bf;
+}
+
+[data-theme="dark"] .btn-primary:hover, [data-theme="dark"] .btn-primary:active {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+	/* color: MISSING; */
+}
+
+[data-theme="dark"] .btn-primary:active:hover {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+}
+
+[data-theme="dark"] .btn-success {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+	/* color: MISSING; */
+}
+
+[data-theme="dark"] .btn-success:hover, [data-theme="dark"] .btn-success:active {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
+	/* color: MISSING; */
+}
+
+[data-theme="dark"] .btn-success:active:hover {
+	/* background-color: MISSING; */
+	/* border-color: MISSING; */
 }
 
 [data-theme="dark"] .pagination>li>a {
@@ -255,6 +296,7 @@ option:checked {
 [data-theme="dark"] .well {
     color: #ddd;
     background-color: #444;
+	/* border-color: MISSING; */
 }
 
 [data-theme="dark"] option {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -344,3 +344,6 @@ option:checked {
 	border-top-color: #3d3d3d;
 }
 
+[data-theme="dark"] .table>thead>tr>th, [data-theme="dark"] .table>tbody>tr>td {
+	border-color: #444;
+}

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -58,6 +58,16 @@ a.donate-link:hover {
 	color: #acd0f6;
 }
 
+select {
+	background-color: #fff;
+	color: inherit;
+}
+
+option:checked {
+	background-color: #bbb;
+	color: #222;
+}
+
 [data-theme="dark"] {
     background-color: #111 !important;
     color: #eee;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -64,6 +64,10 @@ a.donate-link:hover {
     color: #6ae;
 }
 
+[data-theme="dark"] a:hover {
+	color: #acd0f6;
+}
+
 [data-theme="dark"] .form-control {
     background-color: #222;
     color: #eee;
@@ -230,3 +234,13 @@ a.donate-link:hover {
 [data-theme="dark"] code {
     color: white;
 }
+
+[data-theme="dark"] .breadcrumb {
+	background-color: #222;
+	color: #eee;
+}
+
+[data-theme="dark"] .breadcrumb>.active {
+	color: inherit;
+}
+

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -265,3 +265,7 @@ a.donate-link:hover {
 	border-bottom-color: #3d3d3d;
 }
 
+[data-theme="dark"] hr {
+	border-top-color: #3d3d3d;
+}
+

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -50,6 +50,14 @@ a.donate-link:hover {
     color: white !important;
 }
 
+/* Use dark mode link colors on navbar */
+.navbar-inverse .navbar-right > a {
+	color: #6ae;
+}
+.navbar-inverse .navbar-right > a:hover {
+	color: #acd0f6;
+}
+
 [data-theme="dark"] {
     background-color: #111 !important;
     color: #eee;


### PR DESCRIPTION
Some elements are missing CSS rules to make them display correctly in both themes. This pull request notes where rules are missing, and fills in some of them.

More specifically, it:
- Specifies colors for `<select>` and `<option>` in light mode. (This fixes #399.)
- Fixes a typo which prevented the custom `<code>` style from applying, and adds a dark-mode version.
- Makes the navbar (which is always dark) use the dark-mode link color even in light mode.
- Specifies dark-mode colors for some borders and dividers that were falling back on their light-mode colors.
- Specifies `:hover`/`:active` color variations for a few elements that lacked them in dark mode.
- Adds comments documenting where dark-mode colors are still missing. (Filling in these colors should fully fix #394 and #395.)