### PR TITLE
Improve content warning explanation (fixes #220)

### DIFF
--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -196,7 +196,7 @@ Optionally, choose from the menu below a rough estimate of how much time you wou
 You may optionally provide a brief warning that your work contains emotionally intense content - <a href="https://accessible.games/accessible-player-experiences/challenge-patterns/moderation-in-all-things/">what the AbleGamers Foundation describes</a> as “surprise, violence, gore, or sexual themes”. Your warning text, if present, will appear by your game's blurb on the IFComp ballot page, with the label "<strong>Content warning:</strong>". Players will have the option to hide content warnings from their ballots.
 </p>
 
-<p>Whether you provide a warning, and how you choose to word it, is up to you. <a href="https://ifcomp.org/about/faq#content-warnings" target="ifcomp-faq">See the FAQ for more information on IFComp’s policies and suggestions regarding content warnings.</a> We do ask that you use this field only for real and useful content warnings, and not humor or irony. For instance, it would not be appropriate to state “Contains trace amounts of peanuts” here. (You can put that sort of thing in your blurb, if you want...)</p>
+<p>Whether you provide a warning, and how you choose to word it, is up to you. <a href="https://ifcomp.org/about/faq#content-warnings" target="ifcomp-faq">See the FAQ for more information on IFComp’s policies and suggestions regarding content warnings.</a> We do ask that you use this field only for real and useful content warnings. Humor and irony (e.g. "Contains trace amounts of peanuts") can be put in the blurb instead.</p>
 
 [% form.field('warning').render %]
 </div>

--- a/IFComp/root/src/entry/_form.tt
+++ b/IFComp/root/src/entry/_form.tt
@@ -193,7 +193,7 @@ Optionally, choose from the menu below a rough estimate of how much time you wou
 <div class="panel-heading"><h2>Content warnings</h2></div>
 <div class="panel-body">
 <p>
-You may optionally provide a brief warning that your work contains emotionally intense content - <a href="https://accessible.games/accessible-player-experiences/challenge-patterns/moderation-in-all-things/">what the AbleGamers Foundation describes</a> as “surprise, violence, gore, or sexual themes”. Your warning text, if present, will appear by your game's blurb on the IFComp ballot page, with the label "<strong>Content warning:</strong>". Players will have the option to hide content warnings from their ballots.
+You may optionally provide a brief warning that your work contains emotionally intense content - <a href="https://accessible.games/accessible-player-experiences/challenge-patterns/moderation-in-all-things/">what the AbleGamers Foundation describes</a> as “surprise, violence, gore, or sexual themes”. Your warning text, if present, will appear by your game's blurb on the IFComp ballot page, with the label "<strong>Content warning:</strong>". <!-- Players will have the option to hide content warnings from their ballots. -->
 </p>
 
 <p>Whether you provide a warning, and how you choose to word it, is up to you. <a href="https://ifcomp.org/about/faq#content-warnings" target="ifcomp-faq">See the FAQ for more information on IFComp’s policies and suggestions regarding content warnings.</a> We do ask that you use this field only for real and useful content warnings. Humor and irony (e.g. "Contains trace amounts of peanuts") can be put in the blurb instead.</p>


### PR DESCRIPTION
This pull request updates the explanation of content warnings on the entry registration form by:
1. Using the clearer, more succinct wording suggested in #220:
    > We do ask that you use this field only for real and useful content warnings. Humor and irony (e.g. "Contains trace amounts of peanuts") can be put in the blurb instead.
2. Commenting out the line "Players will have the option to hide content warnings from their ballots", as that feature hasn't actually been implemented yet. (See #173.)