### PR TITLE
Add remaining dark mode colors (fixes #394, #395)

### DIFF
--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -196,7 +196,7 @@ option:checked {
 	border-color: #363696;
 }
 
-[data-theme="dark"] .btn-primary:active:hover {
+[data-theme="dark"] .btn-primary:active:hover, [data-theme="dark"] .btn-primary:active:focus {
 	background-color: #363696;
 	border-color: #44b;
 	color: #b3d4ff;
@@ -213,7 +213,7 @@ option:checked {
 	border-color: #327b32;
 }
 
-[data-theme="dark"] .btn-success:active:hover {
+[data-theme="dark"] .btn-success:active:hover, [data-theme="dark"] .btn-success:active:focus {
 	background-color: #327b32;
 	border-color: #378637;
 	color: #e9fce9;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -101,12 +101,13 @@ option:checked {
 }
 
 [data-theme="dark"] .panel-default {
-  border-color: #444;\
+  border-color: #444;
 }
 
 [data-theme="dark"] .panel-heading {
     background-color: #333;
     color: #eee;
+	border-color: #444;
 }
 
 [data-theme="dark"] .panel-body {
@@ -355,4 +356,8 @@ option:checked {
 
 [data-theme="dark"] .table>thead>tr>th, [data-theme="dark"] .table>tbody>tr>td {
 	border-color: #444;
+}
+
+[data-theme="dark"] blockquote {
+	border-color: #3d3d3d;
 }

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -142,15 +142,15 @@ option:checked {
 }
 
 [data-theme="dark"] .alert-success {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
-	/* color: MISSING; */
+	background-color: #274511;
+	border-color: #3e6d1c;
+	color: #d2f4be;
 }
 
 [data-theme="dark"] .alert-danger {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
-	/* color: MISSING; */
+	background-color: #451211;
+	border-color: #6d1e1c;
+	color: #f4bebe;
 }
 
 [data-theme="dark"] .label {
@@ -365,4 +365,3 @@ option:checked {
 [data-theme="dark"] .has-error .checkbox, .has-error .checkbox-inline, .has-error .control-label, .has-error .help-block, .has-error .radio, .has-error .radio-inline, .has-error.checkbox label, .has-error.checkbox-inline label, .has-error.radio label, .has-error.radio-inline label {
 	color: #e69999;
 }
-

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -203,20 +203,20 @@ option:checked {
 }
 
 [data-theme="dark"] .btn-success {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
-	/* color: MISSING; */
+	background-color: #215421;
+	border-color: #2b692b;
+	color: #d2f9d2;
 }
 
 [data-theme="dark"] .btn-success:hover, [data-theme="dark"] .btn-success:active {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
-	/* color: MISSING; */
+	background-color: #2a6a2a;
+	border-color: #327b32;
 }
 
 [data-theme="dark"] .btn-success:active:hover {
-	/* background-color: MISSING; */
-	/* border-color: MISSING; */
+	background-color: #327b32;
+	border-color: #378637;
+	color: #e9fce9;
 }
 
 [data-theme="dark"] .pagination>li>a {

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -361,3 +361,8 @@ option:checked {
 [data-theme="dark"] blockquote {
 	border-color: #3d3d3d;
 }
+
+[data-theme="dark"] .has-error .checkbox, .has-error .checkbox-inline, .has-error .control-label, .has-error .help-block, .has-error .radio, .has-error .radio-inline, .has-error.checkbox label, .has-error.checkbox-inline label, .has-error.radio label, .has-error.radio-inline label {
+	color: #e69999;
+}
+

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -219,6 +219,23 @@ option:checked {
 	color: #e9fce9;
 }
 
+[data-theme="dark"] .btn-danger {
+	background-color: MISSING;
+	border-color: MISSING;
+	color: MISSING;
+}
+
+[data-theme="dark"] .btn-danger:hover, [data-theme="dark"] .btn-danger:active {
+	background-color: MISSING;
+	border-color: MISSING;
+}
+
+[data-theme="dark"] .btn-danger:active:hover, [data-theme="dark"] .btn-danger:active:focus {
+	background-color: MISSING;
+	border-color: MISSING;
+	color: MISSING;
+}
+
 [data-theme="dark"] .pagination>li>a {
     background-color: #222;
     color: #eee;

--- a/IFComp/root/static/css/ifcomp.css
+++ b/IFComp/root/static/css/ifcomp.css
@@ -220,20 +220,20 @@ option:checked {
 }
 
 [data-theme="dark"] .btn-danger {
-	background-color: MISSING;
-	border-color: MISSING;
-	color: MISSING;
+	background-color: #732a26;
+	border-color: #8e322f;
+	color: #f9d3d2;
 }
 
 [data-theme="dark"] .btn-danger:hover, [data-theme="dark"] .btn-danger:active {
-	background-color: MISSING;
-	border-color: MISSING;
+	background-color: #8e322f;
+	border-color: #a13936;
 }
 
 [data-theme="dark"] .btn-danger:active:hover, [data-theme="dark"] .btn-danger:active:focus {
-	background-color: MISSING;
-	border-color: MISSING;
-	color: MISSING;
+	background-color: #a13936;
+	border-color: #ac3d39;
+	color: #fce4e3;
 }
 
 [data-theme="dark"] .pagination>li>a {


### PR DESCRIPTION
This pull request:
- Adds a dark mode palette for the `.alert-danger` and `.alert-success` infobox classes (based on existing dark mode colors for `alert-info`), and the `.btn-danger` and `.btn-success` button classes (based on existing dark mode colors for `.btn-primary`)
- Changes the dark-red warning label on form fields with errors to light red in dark mode
- Fixes a few borders I missed last time, as well as a place where buttons were falling back to light-mode colors

This fixes #395, and should fully fix #394 if I haven't missed anything.