### PR TITLE
Allow cheez to download a CSV of results

### DIFF
--- a/IFComp/lib/IFComp/Controller/Admin.pm
+++ b/IFComp/lib/IFComp/Controller/Admin.pm
@@ -46,6 +46,13 @@ sub index : Chained( 'root' ) : PathPart('') : Args(0) {
 sub ballotcsv : Chained( 'root' ) : Args(0) {
     my ( $self, $c ) = @_;
 
+    unless ( $c->user
+        && $c->check_any_user_role( 'curator', ) )
+    {
+        $c->detach('/error_403');
+        return;
+    }
+
     my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
     my @entries      = $current_comp->entries();
 
@@ -83,6 +90,13 @@ sub ballotcsv : Chained( 'root' ) : Args(0) {
 
 sub resultscsv : Chained( 'root' ) : Args(0) {
     my ( $self, $c ) = @_;
+
+    unless ( $c->user
+        && $c->check_any_user_role( 'cheez', ) )
+    {
+        $c->detach('/error_403');
+        return;
+    }
 
     my $current_comp = $c->model('IFCompDB::Comp')->current_comp;
     my @entries      = $current_comp->entries();

--- a/IFComp/lib/IFComp/Controller/Admin.pm
+++ b/IFComp/lib/IFComp/Controller/Admin.pm
@@ -92,8 +92,10 @@ sub resultscsv : Chained( 'root' ) : Args(0) {
 
     my $output = "";
     open my $fh, ">:encoding(utf8)", \$output or die "open fail $!";
-    $csv->column_names( "author", "title", "place",
-        "MissC", "average", "stddev", "total_votes" );
+    $csv->column_names(
+        "author",  "title",  "place", "MissC",
+        "average", "stddev", "total_votes"
+    );
 
     for my $entry ( $current_comp->entries ) {
         $csv->print(

--- a/IFComp/root/src/admin/index.tt
+++ b/IFComp/root/src/admin/index.tt
@@ -15,10 +15,10 @@
         <li><a href="[% c.uri_for('/admin/feedback/') %]">Feedback</a></li>
         <li><a href="[% c.uri_for('/admin/genai/') %]">Generative AI Responses</a></li>
         <li><a href="[% c.uri_for_action('/admin/ballotcsv') %]">Download CSV of Entries</a></li>
-        <li><a href="[% c.uri_for_action('/admin/resultscsv') %]">Download CSV of Results</a></li>
         [% END %]
         [% IF c.check_user_roles( 'cheez' ) %]
         <li><a href="[% c.uri_for('/admin/validation/') %]">User Validation</a></li>
+        <li><a href="[% c.uri_for_action('/admin/resultscsv') %]">Download CSV of Results</a></li>
         [% END %]
         [% IF c.check_user_roles( 'prizemanager' ) %]
         <li><a href="[% c.uri_for('/admin/prizes/list') %]">Prize Management</a></li>

--- a/IFComp/root/src/admin/index.tt
+++ b/IFComp/root/src/admin/index.tt
@@ -15,6 +15,7 @@
         <li><a href="[% c.uri_for('/admin/feedback/') %]">Feedback</a></li>
         <li><a href="[% c.uri_for('/admin/genai/') %]">Generative AI Responses</a></li>
         <li><a href="[% c.uri_for_action('/admin/ballotcsv') %]">Download CSV of Entries</a></li>
+        <li><a href="[% c.uri_for_action('/admin/resultscsv') %]">Download CSV of Results</a></li>
         [% END %]
         [% IF c.check_user_roles( 'cheez' ) %]
         <li><a href="[% c.uri_for('/admin/validation/') %]">User Validation</a></li>


### PR DESCRIPTION
Adds the link "Download CSV of Results" to /admin. The CSV lists each entry's author and title, place in the overall and Miss Congeniality contests, average score, standard deviation, and total votes cast.

(Like the [ballot CSV](https://github.com/iftechfoundation/ifcomp/pull/409), it doesn't list the column names yet.)