### PR TITLE
Remove 'Update Entry' links after judging ends

### DIFF
--- a/IFComp/root/src/entry/list.tt
+++ b/IFComp/root/src/entry/list.tt
@@ -42,6 +42,7 @@
     [% IF (
         ( current_comp.status != 'over' ) 
         && ( current_comp.status != 'closed_to_entries' )
+        && ( current_comp.status != 'processing_votes' )
        )
     %]
         <a href="[% c.uri_for_action( '/entry/update', [ entry.id ] ) %]">[% entry.title %]</a> <em>(entry ID: [% entry.id %])</em> &mdash;


### PR DESCRIPTION
Fixes #413.

Update Entry becomes inaccessible in phase 6 (`processing_votes`), but /entry still links to it until phase 7 (`over`). This pull request disables the links during phase 6 as well.