### PR TITLE
Disable rating controls after voting closes (fixes #412)

### DIFF
--- a/IFComp/root/lib/site/header
+++ b/IFComp/root/lib/site/header
@@ -23,7 +23,7 @@ END;
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-            [% IF current_comp.status == 'open_for_judging' %]
+            [% IF current_comp.status == 'open_for_judging' || 'processing_votes' %]
               <li><a href="/ballot/">Entries</a></li>
             [% ELSE %]
               <li><a href="/comp/">Results</a></li>

--- a/IFComp/root/src/_rating_controls.tt
+++ b/IFComp/root/src/_rating_controls.tt
@@ -1,7 +1,7 @@
 [% IF c.user.get_object.can_vote_for(entry) %]
 
     <div class="rating-controls" style="float: right;">
-        <p>Your rating: <select data-entry="[% entry.id %]" class="rating-select">
+        <p>Your rating: <select data-entry="[% entry.id %]" class="rating-select"[% IF current_comp.status == 'processing_votes' %] disabled[% END %]>
             <option value="0">None</option>
             [% number = 1 %]
             [% WHILE number <= 10 %]
@@ -9,9 +9,11 @@
                 [% number = number + 1 %]
             [% END %]
         </select>
+        [% IF current_comp.status == 'open_for_judging' %]
         <span class="feedback-link" id="feedback-link-[% entry.id %]">
             <a href="[% c.uri_for_action( '/ballot/feedback', entry.id ) %]">Add / edit feedback</a>
         </span>
+        [% END %]
         <span id="rating-status-[% entry.id %]-spinner" class="label label-default waiting" style="display:none">Submitting...</span>
         <span id="rating-status-[% entry.id %]-success" class="label label-success success" style="display:none">Rating recorded!</span>
         <span id="rating-status-[% entry.id %]-failure" class="label label-danger danger" style="display:none">Rating not recorded! (Uh oh. Contact ifcomp@ifcomp.org about this, please.)</span>

--- a/IFComp/root/src/ballot/index.tt
+++ b/IFComp/root/src/ballot/index.tt
@@ -49,7 +49,11 @@
 
 <h1 id="browse" class="page-header">Browse and play the games</h1>
 
-<p>Have a look at our <a href="[% c.uri_for('/about/file_formats') %]" target="_blank">guide to IF formats</a> for some additional information on the various download-flavors you'll find below. And for a more compact list of this year's entries, <a href="/ballot/vote/">see the voting ballot</a>.</p>
+<p>Have a look at our <a href="[% c.uri_for('/about/file_formats') %]" target="_blank">guide to IF formats</a> for some additional information on the various download-flavors you'll find below.
+[% IF current_comp.status == 'open_for_judging' %]
+And for a more compact list of this year's entries, <a href="/ballot/vote/">see the voting ballot</a>.
+[% END %]
+</p>
 
 <p>Please note that some entries, when played online through this website, collect anonymous transcripts of player input for the benefit of those entries' authors. You can opt out of this by downloading and playing these entries offline. <a href="/about/transcripts">Read this note for more information.</a></p>
 

--- a/IFComp/root/src/welcome.tt2
+++ b/IFComp/root/src/welcome.tt2
@@ -65,7 +65,7 @@ All entries are in and being prepared for release. The judging period will begin
 [% ELSIF current_comp.status == 'open_for_judging' %]
 <a href="[% c.uri_for('/ballot') %]">The games of the [% current_comp.year %] Interactive Fiction Competition are ready for judging!</a> <em>Anyone can be a judge</em>: just play and <a href="[% c.uri_for('/ballot/vote') %]">rate</a> at least five games by [% current_comp.judging_ends.month_name %] [% current_comp.judging_ends.day %]. <a href="[% c.uri_for('/about/schedule') %]">See the full schedule</a>.
 [% ELSIF current_comp.status == 'processing_votes' %]
-Voting has closed! We're tallying up the results now. Final results will be posted soon. <a href="[% c.uri_for('/about/schedule') %]">See the full schedule</a>. (You can still <a href="[% c.uri_for('/comp') %]">browse and play the games</a>, in the meantime.)
+Voting has closed! We're tallying up the results now. Final results will be posted soon. <a href="[% c.uri_for('/about/schedule') %]">See the full schedule</a>. (You can still <a href="[% c.uri_for('/ballot') %]">browse and play the games</a>, in the meantime.)
 [% ELSE %]
 The [% current_comp.year %] IFComp is over. Congratulations to the first-place winner[% IF current_comp.winners.size > 1 %]s[% END %], [% winner_count = 1 %][% FOR winner IN current_comp.winners %]<em>[% winner.title %]</em> by [% INCLUDE author_name.tt entry=winner suppress_links=1 | trim %][% IF winner_count < current_comp.winners.size %] and [% END %][% winner_count = winner_count + 1 %][% END %]!</p>
 


### PR DESCRIPTION
During comp phase 6 (`processing_votes`), rating controls are available but nonfunctional on /ballot. This pull request makes the following changes during phase 6:
- Disables the rating dropdown on /ballot. (Previously it was enabled but threw an error when used.)
- Removes the link to /ballot/vote and the "Add / edit feedback" links from /ballot. (Previously they just led to 403s.)
- Changes header and main page links from "Results" (/comp) to "Entries" (/ballot). (/comp redirects to /ballot during phase 6, since the results aren't ready yet.)