### PR TITLE
Remove extra • separator before empty game metadata fields

### DIFF
--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -49,20 +49,29 @@
 
         <p><em>
         [% IF entry.genre %]
-        <span itemprop="genre">[% entry.genre.ucfirst | html %]</span> •
+        <span itemprop="genre">[% entry.genre.ucfirst | html %]</span>
         [% END %]
 
         [% IF entry.playtime %]
-        <span itemprop="size">[% entry.playtime.ucfirst %]</span> •
+        [% IF entry.genre %]
+        •
+        [% END %]
+        <span itemprop="size">[% entry.playtime.ucfirst %]</span>
         [% END %]
 
+        [% IF entry.style && ( entry.genre || entry.playtime ) %]
+        •
+        [% END %]
         [% IF entry.style == 'parser' %]
-        <span itemprop="interactivityType">Parser-based</span> •
+        <span itemprop="interactivityType">Parser-based</span>
         [% ELSIF entry.style == 'choice' %]
-        <span itemprop="interactivityType">Choice-based</span> •
+        <span itemprop="interactivityType">Choice-based</span>
         [% END %]
 
         [% UNLESS entry.platform == 'other' %]
+        [% IF entry.genre || entry.playtime || entry.style %]
+        •
+        [% END %]
         [% IF entry.platform == 'parchment' || entry.platform == 'inform-website' || entry.platform == 'inform' || entry.platform == 'quixe' || entry.platform == 'quixe2' %]
             [% IF entry.is_zcode %]
             <span itemprop="gamePlatform">Z-code</span> [% INCLUDE guide_link %]

--- a/IFComp/root/src/comp/cover_sheet.tt
+++ b/IFComp/root/src/comp/cover_sheet.tt
@@ -49,20 +49,29 @@ judging on [% comp.judging_begins.strftime( '%{month_name} %{day}' ) %], [% comp
 
         <p><em>
         [% IF entry.genre %]
-        [% entry.genre.ucfirst | html %] •
+        [% entry.genre.ucfirst | html %]
         [% END %]
 
         [% IF entry.playtime %]
-        [% entry.playtime.ucfirst %] •
+        [% IF entry.genre %]
+        •
+        [% END %]
+        [% entry.playtime.ucfirst %]
         [% END %]
 
+        [% IF entry.style && ( entry.genre || entry.playtime ) %]
+        •
+        [% END %]
         [% IF entry.style == 'parser' %]
-        Parser-based •
+        Parser-based
         [% ELSIF entry.style == 'choice' %]
-        Choice-based •
+        Choice-based
         [% END %]
 
         [% UNLESS entry.platform == 'other' %]
+        [% IF entry.genre || entry.playtime || entry.style %]
+        •
+        [% END %]
         [% IF entry.platform == 'parchment' || entry.platform == 'inform-website' || entry.platform == 'inform' || entry.platform == 'quixe' || entry.platform == 'quixe2' %]
             [% IF entry.is_zcode %]
             Z-code


### PR DESCRIPTION
Entry listings on /ballot and /comp include a bullet after each metadata field. This works as long as the last field (platform) isn't blank:
> _Horror • Half an hour • Web-based_

However, the platform field is left blank if set to "Other", which results in [dangling separators](https://ifcomp.org/ballot#entry-3047):
> _Fantasy • Two hours •_ 

This pull request tweaks the template to print separators only between two non-empty fields.

(A simpler fix would be to just print "Other", but I'm assuming that decision was made for a reason.)