### PR TITLE
Add public JSON of entry IFDB IDs, platform, and place

### DIFF
--- a/IFComp/t/controller_Comp.t
+++ b/IFComp/t/controller_Comp.t
@@ -29,4 +29,6 @@ $current_comp = $schema->resultset('Comp')->current_comp;
 is( $current_comp->ok_to_reveal_pseudonyms,
     1, "pseudonyms can be revealed now if desired" );
 
+$mech->get_ok( 'http://localhost/comp/' . $current_comp->year . '/json' );
+
 done_testing();


### PR DESCRIPTION
The main thing IFDB needs this for is to see the the `platform` (+ `is_zcode`) and `ifdb_id` for each entry, which is not visible on `/ballot`, so we can't access it via microdata.

Plus, once the competition is over, it's convenient to know the `place` (and/or `is_disqualified`) for each entry, too.

I did not try to put other data here that is visible via microdata, e.g. author, blurb, etc. partly because that is visible in microdata, but also because some of the information has complex display rules (co-authors, pseudonyms, etc.) The best way to make sure we're using IFComp's latest rules around author display names etc. is to just scrape the microdata off of whatever IFComp is currently displaying, since competition organizers do scrutinize the ballot closely.