### PR TITLE
populate_ifdb_ids: Search IFDB by `competitionid:`, match by entry ID

### DIFF
--- a/IFComp/cpanfile
+++ b/IFComp/cpanfile
@@ -49,6 +49,7 @@ requires 'Unicode::Normalize';
 requires 'String::Random';
 requires 'Template::Plugin::Number::Format';
 requires 'Text::CSV::Encoded';
+requires 'XML::LibXML';
 
 test_requires 'File::Copy::Recursive';
 test_requires 'Test::More' => '0.88';

--- a/IFComp/script/populate_ifdb_ids.pl
+++ b/IFComp/script/populate_ifdb_ids.pl
@@ -13,47 +13,95 @@ use Readonly;
 use lib "$FindBin::Bin/../lib";
 use IFComp::Schema;
 
+use XML::LibXML;
+
 use open ':std', ':encoding(UTF-8)';
 
 Readonly my $PAUSE_BETWEEN_QUERIES => 1;
 
-my $schema = IFComp::Schema->connect( 'dbi:mysql:ifcomp', 'root', '',
-    { mysql_enable_utf8 => 1 } );
+my $schema = IFComp::Schema->connect( 'dbi:mysql:ifcomp',
+    'root', '', { mysql_enable_utf8 => 1 } );
 $schema->entry_directory( Path::Class::Dir->new("$FindBin::Bin/../entries") );
 
 my $current_comp = $schema->resultset('Comp')->current_comp;
 
 my $ua = LWP::UserAgent->new;
 
+my $year = $current_comp->year;
+
+my $ifdb_url = "https://ifdb.org";
+
+# my $ifdb_url = "http://localhost:8083/";
+
+# Search for the current year's competition in the series:Annual Interactive Fiction Competition
+
+my $competition_search_year_uri =
+    "$ifdb_url/search?comp&searchfor=$year%20series%3AAnnual+Interactive+Fiction+Competition&xml";
+
+my $competition_tuid = @{ XML::LibXML->load_xml(
+        string => $ua->get($competition_search_year_uri)->content
+    )->getElementsByTagName("tuid")
+}[0]->textContent;
+
+print "competition_tuid: $competition_tuid\n\n";
+
+sleep($PAUSE_BETWEEN_QUERIES);
+
+# Search for all games with that competitionid
+
+my $competition_search_uri =
+    "$ifdb_url/search?searchfor=competitionid:$competition_tuid&pg=all&sortby=ttl&xml";
+
+my @games = XML::LibXML->load_xml(
+    string => $ua->get($competition_search_uri)->content )
+    ->getElementsByTagName("game");
+
+my @tuids =
+    map { @{ $_->getElementsByTagName('tuid') }[0]->textContent } @games;
+
+sub entry_for_tuid {
+    my $tuid = shift;
+
+    # load the ifiction (XML) for the game
+    my $ifiction_uri = "$ifdb_url/viewgame?id=$tuid&ifiction";
+
+    sleep($PAUSE_BETWEEN_QUERIES);
+
+    # Find all the external links
+    my @links =
+        @{ XML::LibXML->load_xml( string => $ua->get($ifiction_uri)->content )
+            ->getElementsByTagName("links") }[0]
+        ->getElementsByTagName("link");
+
+    # Find the link whose URL looks like a ballot link, containing an IFComp entry ID
+    foreach my $link (@links) {
+        my $url = @{ $link->getElementsByTagName("url") }[0]->textContent;
+        if ( $url =~ /^https:\/\/ifcomp.org\/ballot\/#entry-(\d+)$/ ) {
+            my $entry_id = $1;
+            print "entry_id $entry_id => $tuid\n";
+            return $1;
+        }
+    }
+}
+
+my %entries = map { entry_for_tuid($_) => $_ } @tuids;
+
 for my $entry ( $current_comp->entries ) {
 
     next unless $entry->is_qualified;
 
-    my $title = $entry->title;
-    my $year  = $current_comp->year;
+    my $entry_id = $entry->id;
+    my $title    = $entry->title;
+    my $ifdb_id  = $entries{ $entry->id };
 
-    my $query_string = "$title published:$year";
-    $query_string =~ s/ /+/g;
-    my $uri = "https://ifdb.org/search?xml&game&searchfor=$query_string";
-
-    print "$uri\n\n";
-
-    my $response = $ua->get($uri);
-
-    my $escaped_title = quotemeta $title;
-    my ($ifdb_id) = $response->content
-        =~ m{<tuid>([\w\d]+?)</tuid><title>\s*$escaped_title\s*</title>}i;
     if ($ifdb_id) {
         $entry->ifdb_id($ifdb_id);
         $entry->update;
-        warn "$title has the IFDB $ifdb_id\n";
+        warn "$title ($entry_id) has the IFDB $ifdb_id\n";
     }
     else {
-        my $entry_id = $entry->id;
         warn
             "*** WARNING: Couldn't find an IFDB ID for $title ($entry_id).\n";
     }
-
-    sleep($PAUSE_BETWEEN_QUERIES);
 }
 


### PR DESCRIPTION
Instead of searching for games by title published during the current calendar year, it'll be more accurate to search IFDB for the current year's competition, then search for games with that competitionid. For each game, we find a link to its IFComp ballot entry, which contains a ballot entry ID.

Fixes #142

I tested this using Docker, but it was kinda thorny, so I'll make a note here of how I did it:

1. I launched IFComp via Docker. I had to `docker compose down && docker compose up --build` to install the XML parser I'm using.
2. In `IFComp-Dev`, I ran `script/change_comp_phase.sh 5` to open the competition for judging.
3. I ran IFDB via Docker on port 8083 (modifying the port in `docker-compose.yml`)
4. I used the [IFComp importer](https://github.com/iftechfoundation/ifdb/tree/main/importers/ifcomp). I edited `extract-microdata.mjs` to point to my local instance of IFComp at `http://localhost:8080`.
5. That generated a `microdata.json` full of links to `http://localhost:8080/ballot`, so I did a find-and-replace to turn those into links to `https://ifcomp.org/ballot`.
6. Then, I ran `process-cover-art.mjs`, `submit-games.mjs`, and `tag-games.mjs`, creating a bunch of games in my local Docker IFDB.
7. I created an IFComp 2024 competition in my Docker instance, matching the name and series of the one on ifdb.org, and added all of the newly created games to that competition.
8. I manually edited `populate_ifdb_ids.pl`.
    * I changed the `DBI` connection string to `dbi:mysql:database=ifcomp;host=db` (because otherwise it couldn't find the Dockerized database)
    * I commented out the `ifdb.org` URL and replaced it with a link to my local Docker instance. I couldn't actually use `localhost` for this for weird Docker networking reasons, so I used my local wifi IP `192.168.x.x` address.
9. I ran `IFComp-Dev/script/shell.sh` and ran `script/populate_ifdb_ids.pl`. It worked!

```
competition_tuid: qsqlmrbun65z8m5p

entry_id 101 => ktsmvrw09kf3cskv
entry_id 106 => bdf6nkhddfbgxzc
entry_id 105 => 3qvvpz3plnlwldcw
entry_id 103 => wc5u5khklo3k64af
entry_id 108 => ct461ebbuwkvh1en
entry_id 109 => 5mc1k87vp7n4l0bq
entry_id 100 => 70maovg7yfmalax6
entry_id 104 => vpop1ywv9w7tko7q
entry_id 107 => 84jd9pr3ouqppu4v
Test Z-code game (100) has the IFDB 70maovg7yfmalax6
Test Glulx game (101) has the IFDB ktsmvrw09kf3cskv
Test Parchment game (103) has the IFDB wc5u5khklo3k64af
Test Z-code website (104) has the IFDB vpop1ywv9w7tko7q
Test non-Inform website (105) has the IFDB 3qvvpz3plnlwldcw
Test HTML page (106) has the IFDB bdf6nkhddfbgxzc
Test Z-code website with buried story file (107) has the IFDB 84jd9pr3ouqppu4v
Test Quest game (108) has the IFDB ct461ebbuwkvh1en
Test TADS game (109) has the IFDB 5mc1k87vp7n4l0bq
```