### PR TITLE
Fix rating controls on /ballot

### DIFF
--- a/IFComp/root/src/_current_entry_row.tt
+++ b/IFComp/root/src/_current_entry_row.tt
@@ -158,11 +158,7 @@
         </div>
         [% END %]        
 
-        [% IF current_comp.status == 'open_for_judging' %]
-        <div class="play-button">
-            <a href="/ballot/vote" class="btn btn-default"><span class="glyphicon glyphicon-edit"></span> Vote</a>
-        </div>
-        [% END %]
+        [% INCLUDE _rating_controls.tt %]
 
     </div>
 </div>

--- a/IFComp/root/src/_rating_controls.tt
+++ b/IFComp/root/src/_rating_controls.tt
@@ -1,7 +1,7 @@
 [% IF c.user.get_object.can_vote_for(entry) %]
 
     <div class="rating-controls" style="float: right;">
-        <p>Your rating: <select data-entry="[% entry.id %]" class="rating-select"[% IF current_comp.status == 'processing_votes' %] disabled[% END %]>
+        <p>Your rating: <select data-entry="[% entry.id %]" class="rating-select"[% IF current_comp.status == 'processing_votes' %] disabled[% END %] autocomplete="off">
             <option value="0">None</option>
             [% number = 1 %]
             [% WHILE number <= 10 %]

--- a/IFComp/root/src/ballot/index.tt
+++ b/IFComp/root/src/ballot/index.tt
@@ -1,7 +1,3 @@
-<style>
-.rating-controls { display: none }
-</style>
-
 <div class="container">
 
 <div class="jumbotron">

--- a/IFComp/t/controller_Ballot.t
+++ b/IFComp/t/controller_Ballot.t
@@ -46,7 +46,7 @@ IFCompTest::set_phase_after( $schema, 'judging_begins' );
 $mech->get_ok('http://localhost/ballot');
 $mech->content_contains("Balloting Game");
 
-# $mech->content_contains("Your rating");
+$mech->content_contains("Your rating");
 
 $entry->discard_changes;
 


### PR DESCRIPTION
We previously added rating controls to /ballot, but had to remove them due to a bug: Firefox's form autocomplete would try to preserve each dropdown's value when the page was refreshed, which caused ratings to appear next to the wrong games when the order was reshuffled.

This pull request fixes that issue by disabling autocomplete on the rating controls. If we want to allow rating from /ballot, it should be possible now.

I've tested briefly in Firefox and Chrome on Windows 10, and everything appears to work as intended.