### PR TITLE
Upgrade dev environment to Perl 5.34

### DIFF
--- a/IFComp-Dev/docker-app/Dockerfile
+++ b/IFComp-Dev/docker-app/Dockerfile
@@ -1,5 +1,5 @@
 # DOCKER-VERSION 0.3.4
-FROM        perl:5.30.2
+FROM        perl:5.34
 MAINTAINER  Mark Musante mark.musante@gmail.com
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
I wanted to upgrade to a newer version of Perl, but when I tried upgrading to the latest stable version 5.42, `DBD::mysql` failed to install. 5.34 worked, so, here we are.

Fixes #454