### PR TITLE
Use standardized slugs in zip-of-zips

### DIFF
--- a/IFComp/lib/IFComp/Controller/Comp.pm
+++ b/IFComp/lib/IFComp/Controller/Comp.pm
@@ -2,6 +2,7 @@ package IFComp::Controller::Comp;
 use Moose;
 use namespace::autoclean;
 use DateTime;
+use IFComp::Slug qw(entry_slugs_for_comp);
 
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -144,23 +145,28 @@ sub json : Chained('fetch_comp') : PathPart('json') : Args(0) {
     my @entries = $comp->entries->search( { is_disqualified => 0, }, )->all;
 
     $c->response->content_type("application/json");
-    my $j = JSON::Any->new;
+    my $j     = JSON::Any->new;
+    my $slugs = entry_slugs_for_comp($comp);
     my @data;
     if (   $comp->status eq 'open_for_judging'
         || $comp->status eq 'processing_votes' )
     {
         @data = map {
-            {   "id"       => $_->id,
+            my %row = (
+                "id"       => $_->id,
                 "title"    => $_->title,
                 "ifdb_id"  => $_->ifdb_id,
                 "platform" => $_->platform,
                 "is_zcode" => $_->is_zcode,
-            }
+            );
+            $row{slug} = $slugs->{ $_->id } if $_->is_qualified;
+            \%row;
         } @entries;
     }
     else {
         @data = map {
-            {   "id"                      => $_->id,
+            my %row = (
+                "id"                      => $_->id,
                 "title"                   => $_->title,
                 "ifdb_id"                 => $_->ifdb_id,
                 "platform"                => $_->platform,
@@ -180,8 +186,9 @@ sub json : Chained('fetch_comp') : PathPart('json') : Args(0) {
                 "total_8"                 => $_->total_8,
                 "total_9"                 => $_->total_9,
                 "total_10"                => $_->total_10,
-
-            }
+            );
+            $row{slug} = $slugs->{ $_->id } if $_->is_qualified;
+            \%row;
         } @entries;
     }
     $c->response->body( $j->encode( \@data ) );

--- a/IFComp/lib/IFComp/Slug.pm
+++ b/IFComp/lib/IFComp/Slug.pm
@@ -1,0 +1,104 @@
+package IFComp::Slug;
+
+use strict;
+use warnings;
+use utf8;
+
+use Exporter qw(import);
+use Unicode::Normalize qw(NFD);
+
+our @EXPORT_OK = qw(
+    title_to_base_slug
+    entry_slugs_for_entries
+    entry_slugs_for_comp
+);
+
+=head1 NAME
+
+IFComp::Slug - URL-friendly slugs for IFComp entries
+
+=head1 DESCRIPTION
+
+Computes deterministic slugs for qualified IFComp entries. Used by the
+zip-of-zips builder and comp JSON so archive tools can map filenames to
+entry IDs without fuzzy title matching.
+
+=head1 FUNCTIONS
+
+=head2 title_to_base_slug($title)
+
+Returns a URL-friendly slug from an entry title, or C<undef> if nothing
+remains after normalization.
+
+=head2 entry_slugs_for_entries(@entries)
+
+Takes entry objects with C<id> and C<title> methods. Returns a hashref
+mapping entry ID to final slug.
+
+Entries whose base slugs collide case-insensitively all receive an
+C<-{entry_id}> suffix so no bare slug is ambiguous.
+
+=head2 entry_slugs_for_comp($comp)
+
+Convenience wrapper: slugs for all C<is_qualified> entries on a comp.
+
+=cut
+
+sub title_to_base_slug {
+    my ($title) = @_;
+    return undef unless defined $title && length $title;
+
+    $title = NFD($title);
+    $title =~ s/\p{NonspacingMark}//g;
+    $title =~ s/^(?:the|a|an)\s+//i;
+    $title =~ s/[^\p{L}\p{N}\s-]//g;
+    $title =~ s/\s+/_/g;
+    $title =~ s/_+/_/g;
+    $title =~ s/^_+|_+$//g;
+
+    return length $title ? $title : undef;
+}
+
+sub entry_slugs_for_entries {
+    my (@entries) = @_;
+
+    my %base_by_id;
+    my %groups;
+
+    for my $entry (@entries) {
+        my $id        = $entry->id;
+        my $base_slug = title_to_base_slug( $entry->title ) // "entry-$id";
+        $base_by_id{$id} = $base_slug;
+        push @{ $groups{ lc $base_slug } }, $id;
+    }
+
+    my %preferred;
+    for my $id ( keys %base_by_id ) {
+        my $base_slug = $base_by_id{$id};
+        my $group     = $groups{ lc $base_slug };
+        $preferred{$id} = ( @$group == 1 ) ? $base_slug : "$base_slug-$id";
+    }
+
+    # Claim final slugs in ascending ID order so lower IDs keep a contested
+    # name and later entries append -{id} until unique.
+    my %used;    # lc(slug) => 1
+    my %slugs;
+    for my $id ( sort { $a <=> $b } keys %preferred ) {
+        my $slug = $preferred{$id};
+        while ( $used{ lc $slug } ) {
+            $slug = "$slug-$id";
+        }
+        $used{ lc $slug } = 1;
+        $slugs{$id} = $slug;
+    }
+
+    return \%slugs;
+}
+
+sub entry_slugs_for_comp {
+    my ($comp) = @_;
+    my @entries = grep { $_->is_qualified } $comp->entries->all;
+    return entry_slugs_for_entries(@entries);
+}
+
+1;

--- a/IFComp/script/build_zip_of_zips.pl
+++ b/IFComp/script/build_zip_of_zips.pl
@@ -7,93 +7,75 @@ use FindBin;
 
 use lib "$FindBin::Bin/../lib";
 use IFComp::Schema;
+use IFComp::Slug qw(entry_slugs_for_comp);
 
 use Path::Class;
 use File::Basename;
 use Archive::Zip qw(AZ_OK);
-use Unicode::Normalize qw(NFD);
-use Encode qw(decode encode);
 
 my $schema = IFComp::Schema->connect( 'dbi:mysql:ifcomp', 'root', '' );
 $schema->entry_directory( Path::Class::Dir->new("$FindBin::Bin/../entries") );
 my $comp = $schema->resultset('Comp');
 
-my $home = $ENV{HOME} || $ENV{USERPROFILE} || '/var/tmp';
-my $zipdir = dir($home, $comp->current_comp->year);
+my $home   = $ENV{HOME} || $ENV{USERPROFILE} || '/var/tmp';
+my $zipdir = dir( $home, $comp->current_comp->year );
 
-my $games_dir      = $zipdir->subdir('Games');
+my $games_dir        = $zipdir->subdir('Games');
 my $walkthroughs_dir = $zipdir->subdir('Walkthroughs');
 
-$games_dir->mkpath unless -d $games_dir;
+$games_dir->mkpath        unless -d $games_dir;
 $walkthroughs_dir->mkpath unless -d $walkthroughs_dir;
 
-my $count = 0;
+my $current_comp = $comp->current_comp;
+my $slugs        = entry_slugs_for_comp($current_comp);
+my $count        = 0;
 
-for my $entry ( $comp->current_comp->entries->all ) {
+for my $entry ( $current_comp->entries->all ) {
     next unless $entry->is_qualified;
 
     say "Processing: " . $entry->title . " - " . $entry->main_file->stringify;
 
-    my $raw_title = decode('UTF-8', $entry->title);
-
-    my $title = NFD($raw_title);                   # Decompose Unicode characters
-    $title =~ s/\p{NonspacingMark}//g;             # Strip diacritics
-    $title =~ s/[^\x00-\x7F]/_/g;                  # Replace remaining non-ASCII with underscore
-    $title =~ s/[^\w\d\s]//g;                      # Kill remaining non-word characters
-    $title =~ s/ +/ /g;                            # Collapse multiple spaces
-    $title =~ s/^\s+|\s+$//g;                      # Trim leading/trailing whitespace
-
-    unless ($title) {
-        warn "Unable to ascii-ify $raw_title";
-        next;
-    }
-    if ( $raw_title ne $title) {
-	say "\tNew Name: $title";
-    }
+    my $slug = $slugs->{ $entry->id };
 
     my $main_file_obj = $entry->main_file;
     next unless $main_file_obj && -f $main_file_obj->stringify;
 
-    my $src_path = $main_file_obj->stringify;
-    my $dest_main = $games_dir->file("$title.zip");
-
-    # If there's another file with the same name, cheat by
-    # adding the unique ifdb to it.
-    if (-e $dest_main->stringify) {
-	    my $ifdb_id = $entry->ifdb_id;
-	    $dest_main = $games_dir->file("$title-$ifdb_id.zip");
-    }
+    my $src_path  = $main_file_obj->stringify;
+    my $dest_main = $games_dir->file("$slug.zip");
 
     # We want to make sure that all the files in the zip-of-zips are zips.
     # Some authors upload non-zip files (e.g. a single index.html), so we
     # need to zip that up here.
-    if ($src_path =~ /\.zip$/i) {
+    if ( $src_path =~ /\.zip$/i ) {
         $main_file_obj->copy_to($dest_main);
-	say "\tCopied over as zipfile";
-    } else {
-        my $zip = Archive::Zip->new();
-	my $zipfile = $zip->addFile($src_path);
-	unless (defined $zipfile) {
+        say "\tCopied over as $slug.zip";
+    }
+    else {
+        my $zip     = Archive::Zip->new();
+        my $zipfile = $zip->addFile($src_path);
+        unless ( defined $zipfile ) {
             warn "Failed to add file to zip: $!\n";
-	    last;
+            last;
         }
-        unless ($zip->writeToFileNamed($dest_main->stringify) == AZ_OK) {
+        unless ( $zip->writeToFileNamed( $dest_main->stringify ) == AZ_OK ) {
             warn "Failed to write zip file: $!\n";
-	    last;
+            last;
         }
-	say "\tCompressed into zipfile";
+        say "\tCompressed into zipfile";
     }
 
     # ...and, if there's a walkthrough, copy that over as well
-    if ( $entry->walkthrough_file && -f $entry->walkthrough_file->stringify ) {
-        my $walk_ext = (basename($entry->walkthrough_file->stringify) =~ /\.(\w+)$/)[0] || 'txt';
-        my $dest_walk = $walkthroughs_dir->file("$title.$walk_ext");
+    if ( $entry->walkthrough_file && -f $entry->walkthrough_file->stringify )
+    {
+        my $walk_ext =
+            ( basename( $entry->walkthrough_file->stringify ) =~ /\.(\w+)$/ )
+            [0] || 'txt';
+        my $dest_walk = $walkthroughs_dir->file("$slug.$walk_ext");
         $entry->walkthrough_file->copy_to($dest_walk);
-	say "\tIncluded walkthrough";
+        say "\tIncluded walkthrough";
     }
 
     $count++;
 }
 
 print "Processed $count entries.\n";
-

--- a/IFComp/t/slug.t
+++ b/IFComp/t/slug.t
@@ -1,0 +1,98 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+use IFComp::Slug qw(title_to_base_slug entry_slugs_for_entries);
+
+{
+
+    package SlugTestEntry;
+
+    sub new {
+        my ( $class, %args ) = @_;
+        return bless \%args, $class;
+    }
+
+    sub id    { $_[0]->{id} }
+    sub title { $_[0]->{title} }
+}
+
+sub entry {
+    my ( $id, $title ) = @_;
+    return SlugTestEntry->new( id => $id, title => $title );
+}
+
+is( title_to_base_slug("The Wise-Woman's Dog"),
+    'Wise-Womans_Dog',
+    'strips leading article, preserves hyphens, underscores spaces' );
+is( title_to_base_slug("Caf\x{e9} Noir"), 'Cafe_Noir', 'strips diacritics' );
+is( title_to_base_slug('MY GAME'),        'MY_GAME',   'preserves case' );
+is( title_to_base_slug('the foo'),  'foo',  'strips lowercase article' );
+is( title_to_base_slug('A Tale'),   'Tale', 'strips A' );
+is( title_to_base_slug('An Hour'),  'Hour', 'strips An' );
+is( title_to_base_slug("Z\x{f6}e"), 'Zoe',  'handles umlauts' );
+is( title_to_base_slug('  Spaces  '), 'Spaces',
+    'trims and collapses spaces' );
+ok( !defined title_to_base_slug('!!!'),
+    'punctuation-only title returns undef'
+);
+
+my $unique = entry_slugs_for_entries( entry( 100, 'The Foo' ) );
+is( $unique->{100}, 'Foo', 'unique title gets bare slug' );
+
+my $identical = entry_slugs_for_entries(
+    entry( 100, 'The Foo' ),
+    entry( 101, 'The Foo' ),
+);
+is( $identical->{100}, 'Foo-100',
+    'identical titles both get entry-id suffix' );
+is( $identical->{101}, 'Foo-101',
+    'identical titles both get entry-id suffix' );
+
+my $case_only = entry_slugs_for_entries(
+    entry( 100, 'My Game' ),
+    entry( 101, 'MY GAME' ),
+);
+is( $case_only->{100}, 'My_Game-100',
+    'case-only collision suffixes first entry' );
+is( $case_only->{101}, 'MY_GAME-101',
+    'case-only collision suffixes second entry' );
+
+my $triple = entry_slugs_for_entries(
+    entry( 100, 'Same' ),
+    entry( 101, 'Same' ),
+    entry( 102, 'Same' ),
+);
+is( $triple->{100}, 'Same-100', 'three-way collision suffixes all entries' );
+is( $triple->{101}, 'Same-101', 'three-way collision suffixes all entries' );
+is( $triple->{102}, 'Same-102', 'three-way collision suffixes all entries' );
+
+my $empty = entry_slugs_for_entries( entry( 42, '!!!' ) );
+is( $empty->{42}, 'entry-42', 'unslugifiable title falls back to entry id' );
+
+# Two "Foo" entries get Foo-100 / Foo-101; a third titled "Foo-100" must
+# not reuse Foo-100, so it becomes Foo-100-102. Chained titles keep appending.
+my $cross = entry_slugs_for_entries(
+    entry( 100, 'Foo' ),
+    entry( 101, 'Foo' ),
+    entry( 102, 'Foo-100' ),
+    entry( 103, 'Foo-100-102' ),
+);
+is( $cross->{100}, 'Foo-100',     'Foo collision: entry 100 gets Foo-100' );
+is( $cross->{101}, 'Foo-101',     'Foo collision: entry 101 gets Foo-101' );
+is( $cross->{102}, 'Foo-100-102', 'title Foo-100 becomes Foo-100-102' );
+is( $cross->{103}, 'Foo-100-102-103',
+    'title Foo-100-102 becomes Foo-100-102-103' );
+
+my %seen;
+my $duplicate;
+for my $slug ( values %$cross ) {
+    if ( $seen{ lc $slug }++ ) {
+        $duplicate = $slug;
+        last;
+    }
+}
+ok( !defined $duplicate, 'all final slugs are unique' );
+
+done_testing();


### PR DESCRIPTION
This way, the IF Archive team can deterministically know which sub-zips belong to which IFComp entry IDs.